### PR TITLE
feat: 팬덤 분석 도메인 및 pgvector 임베딩 인프라

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16
+    image: pgvector/pgvector:pg16
     container_name: ais-dev-postgres
     ports:
       - "5437:5432"

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -54,7 +54,7 @@ services:
         max-file: "3"
 
   postgres:
-    image: postgres:16
+    image: pgvector/pgvector:pg16
     container_name: ais-prod-postgres
     restart: unless-stopped
     ports:

--- a/packages/core/src/analysis/preprocessing/embedding-persist.ts
+++ b/packages/core/src/analysis/preprocessing/embedding-persist.ts
@@ -1,0 +1,78 @@
+import { sql, isNull } from 'drizzle-orm';
+import { getDb } from '../../db';
+import { articles, comments } from '../../db/schema/collections';
+import { embedTexts } from './embeddings';
+
+/**
+ * 기사에 임베딩을 생성하여 DB에 저장.
+ * 이미 임베딩이 있는 기사는 스킵.
+ */
+export async function persistArticleEmbeddings(articleIds: number[]): Promise<void> {
+  if (articleIds.length === 0) return;
+
+  const db = getDb();
+
+  // 임베딩이 없는 기사만 조회
+  const target = await db
+    .select({ id: articles.id, title: articles.title, content: articles.content })
+    .from(articles)
+    .where(isNull(articles.embedding))
+    .limit(500);
+
+  // 요청된 ID와 교집합
+  const idSet = new Set(articleIds);
+  const toEmbed = target.filter((a) => idSet.has(a.id));
+
+  if (toEmbed.length === 0) return;
+
+  // 텍스트 준비: title + content 앞부분 (deduplicator와 동일 패턴)
+  const texts = toEmbed.map((a) => `${a.title} ${(a.content ?? '').slice(0, 300)}`);
+
+  // 임베딩 생성
+  const embeddings = await embedTexts(texts);
+
+  // DB에 저장
+  for (let i = 0; i < toEmbed.length; i++) {
+    await db
+      .update(articles)
+      .set({ embedding: embeddings[i] } as any)
+      .where(sql`${articles.id} = ${toEmbed[i].id}`);
+  }
+
+  console.error(`[embedding] 기사 임베딩 저장: ${toEmbed.length}건`);
+}
+
+/**
+ * 댓글에 임베딩을 생성하여 DB에 저장.
+ * 이미 임베딩이 있는 댓글은 스킵.
+ */
+export async function persistCommentEmbeddings(commentIds: number[]): Promise<void> {
+  if (commentIds.length === 0) return;
+
+  const db = getDb();
+
+  // 임베딩이 없는 댓글만 조회
+  const target = await db
+    .select({ id: comments.id, content: comments.content })
+    .from(comments)
+    .where(isNull(comments.embedding))
+    .limit(500);
+
+  // 요청된 ID와 교집합
+  const idSet = new Set(commentIds);
+  const toEmbed = target.filter((c) => idSet.has(c.id));
+
+  if (toEmbed.length === 0) return;
+
+  const texts = toEmbed.map((c) => c.content);
+  const embeddings = await embedTexts(texts);
+
+  for (let i = 0; i < toEmbed.length; i++) {
+    await db
+      .update(comments)
+      .set({ embedding: embeddings[i] } as any)
+      .where(sql`${comments.id} = ${toEmbed[i].id}`);
+  }
+
+  console.error(`[embedding] 댓글 임베딩 저장: ${toEmbed.length}건`);
+}

--- a/packages/core/src/db/migrations/0003_enable_pgvector.sql
+++ b/packages/core/src/db/migrations/0003_enable_pgvector.sql
@@ -1,0 +1,2 @@
+-- pgvector 확장 설치
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/packages/core/src/db/migrations/0004_embedding_indexes.sql
+++ b/packages/core/src/db/migrations/0004_embedding_indexes.sql
@@ -1,0 +1,12 @@
+-- 임베딩 HNSW 인덱스 (코사인 거리, 소규모 데이터에 최적화)
+-- 데이터가 충분히 쌓인 후 실행 권장 (초기에는 NULL이 많아 인덱스 효율 낮음)
+
+CREATE INDEX IF NOT EXISTS articles_embedding_hnsw_idx
+  ON articles
+  USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+
+CREATE INDEX IF NOT EXISTS comments_embedding_hnsw_idx
+  ON comments
+  USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);

--- a/packages/core/src/db/schema/collections.ts
+++ b/packages/core/src/db/schema/collections.ts
@@ -10,6 +10,7 @@ import {
   boolean,
   uuid,
 } from 'drizzle-orm/pg-core';
+import { vector384 } from '../types/vector';
 import { teams, users } from './auth';
 import { dataSources } from './sources';
 
@@ -103,6 +104,7 @@ export const articles = pgTable(
     sentimentScore: real('sentiment_score'), // 감정 확신도 (0~1)
     summary: text('summary'), // AI 한 줄 요약
     rawData: jsonb('raw_data'),
+    embedding: vector384('embedding'), // pgvector 임베딩 (multilingual-e5-small, 384차원)
     collectedAt: timestamp('collected_at').defaultNow().notNull(),
   },
   (table) => [uniqueIndex('articles_source_id_idx').on(table.source, table.sourceId)],
@@ -156,6 +158,7 @@ export const comments = pgTable(
     sentiment: text('sentiment'), // 개별 감정 분석 결과: positive | negative | neutral
     sentimentScore: real('sentiment_score'), // 감정 확신도 (0~1)
     rawData: jsonb('raw_data'),
+    embedding: vector384('embedding'), // pgvector 임베딩 (multilingual-e5-small, 384차원)
     collectedAt: timestamp('collected_at').defaultNow().notNull(),
   },
   (table) => [uniqueIndex('comments_source_id_idx').on(table.source, table.sourceId)],

--- a/packages/core/src/db/types/vector.ts
+++ b/packages/core/src/db/types/vector.ts
@@ -1,0 +1,20 @@
+import { customType } from 'drizzle-orm/pg-core';
+
+/**
+ * pgvector vector(384) 컬럼 타입
+ * multilingual-e5-small 임베딩(384차원) 저장용
+ *
+ * JS number[] ↔ pgvector 문자열 표현 간 변환 처리
+ */
+export const vector384 = customType<{ data: number[]; driverData: string }>({
+  dataType() {
+    return 'vector(384)';
+  },
+  fromDriver(value: string): number[] {
+    // pgvector가 '[0.1,0.2,...]' 형태로 반환
+    return JSON.parse(value);
+  },
+  toDriver(value: number[]): string {
+    return `[${value.join(',')}]`;
+  },
+});

--- a/packages/core/src/queue/pipeline-worker.ts
+++ b/packages/core/src/queue/pipeline-worker.ts
@@ -26,6 +26,10 @@ import { dataSources } from '../db/schema/sources';
 import { isPipelineCancelled } from '../pipeline/control';
 import { awaitStageGate } from '../pipeline/pipeline-checks';
 import { createLogger } from '../utils/logger';
+import {
+  persistArticleEmbeddings,
+  persistCommentEmbeddings,
+} from '../analysis/preprocessing/embedding-persist';
 import { triggerAnalysis } from './flows';
 import { COMMUNITY_SOURCES } from './worker-config';
 
@@ -411,6 +415,38 @@ export function createPipelineHandler(): (job: Job) => Promise<any> {
             logger.warn(`[persist] data_sources.lastCollectedAt 갱신 실패 (${snapshot.id}):`, err);
           }
         }
+      }
+
+      // 임베딩 생성 (비차단 — 실패해도 수집 파이프라인에 영향 없음)
+      // persist 단계에서 저장된 기사/댓글의 embedding이 NULL인 것을 백그라운드에서 처리
+      try {
+        const db = getDb();
+        // jobId에 해당하는 임베딩 미생성 기사/댓글을 직접 DB에서 찾아 처리
+        const { articleJobs, commentJobs } = await import('../db/schema/collections');
+        const articleRows = await db
+          .select({ articleId: articleJobs.articleId })
+          .from(articleJobs)
+          .where(eq(articleJobs.jobId, dbJobId));
+        const commentRows = await db
+          .select({ commentId: commentJobs.commentId })
+          .from(commentJobs)
+          .where(eq(commentJobs.jobId, dbJobId));
+
+        const articleIds = articleRows.map((r) => r.articleId);
+        const commentIds = commentRows.map((r) => r.commentId);
+
+        if (articleIds.length > 0) {
+          persistArticleEmbeddings(articleIds).catch((err) =>
+            logger.warn(`[persist] 기사 임베딩 생성 실패:`, err),
+          );
+        }
+        if (commentIds.length > 0) {
+          persistCommentEmbeddings(commentIds).catch((err) =>
+            logger.warn(`[persist] 댓글 임베딩 생성 실패:`, err),
+          );
+        }
+      } catch (err) {
+        logger.warn(`[persist] 임베딩 생성 스킵:`, err);
       }
 
       // D-06: 최종 상태 업데이트 -- dbJobId는 number이므로 parseInt 불필요

--- a/packages/core/src/scripts/backfill-embeddings.ts
+++ b/packages/core/src/scripts/backfill-embeddings.ts
@@ -1,0 +1,101 @@
+/**
+ * 기존 기사/댓글에 임베딩을 백필하는 스크립트
+ *
+ * 사용법:
+ *   pnpm --filter @ai-signalcraft/core tsx src/scripts/backfill-embeddings.ts
+ *   pnpm --filter @ai-signalcraft/core tsx src/scripts/backfill-embeddings.ts --comments-only
+ *   pnpm --filter @ai-signalcraft/core tsx src/scripts/backfill-embeddings.ts --articles-only
+ */
+import 'dotenv/config';
+import { isNull, sql } from 'drizzle-orm';
+import { getDb } from '../db';
+import { articles, comments } from '../db/schema/collections';
+import { embedTexts } from '../analysis/preprocessing/embeddings';
+
+const BATCH_SIZE = 50;
+
+async function backfillArticles(): Promise<number> {
+  const db = getDb();
+  let total = 0;
+
+  while (true) {
+    const rows = await db
+      .select({ id: articles.id, title: articles.title, content: articles.content })
+      .from(articles)
+      .where(isNull(articles.embedding))
+      .limit(BATCH_SIZE);
+
+    if (rows.length === 0) break;
+
+    const texts = rows.map((r) => `${r.title} ${(r.content ?? '').slice(0, 300)}`);
+    const embeddings = await embedTexts(texts);
+
+    for (let i = 0; i < rows.length; i++) {
+      await db
+        .update(articles)
+        .set({ embedding: embeddings[i] } as any)
+        .where(sql`${articles.id} = ${rows[i].id}`);
+    }
+
+    total += rows.length;
+    console.log(`[backfill] 기사: ${total}건 처리 완료`);
+  }
+
+  return total;
+}
+
+async function backfillComments(): Promise<number> {
+  const db = getDb();
+  let total = 0;
+
+  while (true) {
+    const rows = await db
+      .select({ id: comments.id, content: comments.content })
+      .from(comments)
+      .where(isNull(comments.embedding))
+      .limit(BATCH_SIZE);
+
+    if (rows.length === 0) break;
+
+    const texts = rows.map((r) => r.content);
+    const embeddings = await embedTexts(texts);
+
+    for (let i = 0; i < rows.length; i++) {
+      await db
+        .update(comments)
+        .set({ embedding: embeddings[i] } as any)
+        .where(sql`${comments.id} = ${rows[i].id}`);
+    }
+
+    total += rows.length;
+    console.log(`[backfill] 댓글: ${total}건 처리 완료`);
+  }
+
+  return total;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const articlesOnly = args.includes('--articles-only');
+  const commentsOnly = args.includes('--comments-only');
+
+  console.log('[backfill] 임베딩 백필 시작...');
+
+  if (!commentsOnly) {
+    const articleCount = await backfillArticles();
+    console.log(`[backfill] 기사 완료: 총 ${articleCount}건`);
+  }
+
+  if (!articlesOnly) {
+    const commentCount = await backfillComments();
+    console.log(`[backfill] 댓글 완료: 총 ${commentCount}건`);
+  }
+
+  console.log('[backfill] 완료');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[backfill] 오류:', err);
+  process.exit(1);
+});

--- a/packages/core/tests/analysis-schema.test.ts
+++ b/packages/core/tests/analysis-schema.test.ts
@@ -44,7 +44,7 @@ describe('AnalysisModule 인터페이스 + 타입', () => {
     expect(MODULE_MODEL_MAP).toBeDefined();
   });
 
-  it('MODULE_MODEL_MAP이 8개 기본 모듈 + 4개 ADVN 모듈 + integrated-report 매핑을 포함한다', async () => {
+  it('MODULE_MODEL_MAP이 8개 기본 모듈 + 4개 ADVN 모듈 + integrated-report + 4개 팬덤 ADVN 모듈 매핑을 포함한다', async () => {
     const { MODULE_MODEL_MAP } = await import('../src/analysis/types');
 
     const expectedModules = [
@@ -57,11 +57,16 @@ describe('AnalysisModule 인터페이스 + 타입', () => {
       'strategy',
       'final-summary',
       'integrated-report',
-      // Stage 4: ADVN 고급 분석 모듈
+      // Stage 4: ADVN 고급 분석 모듈 (정치 도메인)
       'approval-rating',
       'frame-war',
       'crisis-scenario',
       'win-simulation',
+      // Stage 4: ADVN 고급 분석 모듈 (팬덤 도메인)
+      'fan-loyalty-index',
+      'fandom-narrative-war',
+      'fandom-crisis-scenario',
+      'release-reception-prediction',
     ];
 
     for (const mod of expectedModules) {
@@ -70,7 +75,7 @@ describe('AnalysisModule 인터페이스 + 타입', () => {
       expect(MODULE_MODEL_MAP[mod].model).toBeDefined();
     }
 
-    expect(Object.keys(MODULE_MODEL_MAP).length).toBe(13);
+    expect(Object.keys(MODULE_MODEL_MAP).length).toBe(17);
   });
 });
 


### PR DESCRIPTION
## Summary

- **팬덤 분석 도메인 추가**: political/fandom 도메인 추상화, 4개 팬덤 분석 모듈 (팬 충성도 지수, 팬덤 위기 시나리오, 내러티브 전쟁, 발매 반응 예측) 및 프론트엔드 UI
- **pgvector 임베딩 영구 저장**: Docker 이미지 교체(pgvector/pgvector:pg16), vector(384) 컬럼 추가, HNSW 인덱스, 파이프라인 비차단 임베딩 생성 연동, 백필 스크립트
- **모델 설정 UI 개선**: 분석 모듈별 AI 모델/온도/max_tokens 커스터마이징 기능

## 주요 변경 사항

### 팬덤 분석 도메인
- `packages/core/src/analysis/domain/` — 도메인 추상화 (registry, types, political/fandom)
- `packages/core/src/analysis/modules/fandom/` — 팬덤 전용 4개 분석 모듈 (ADVN Stage 4)
- `apps/web/src/components/advanced/` — 팬덤 분석 UI 카드 4종
- `packages/core/src/analysis/modules/prompt-utils.ts` — 도메인별 프롬프트 분기 유틸

### pgvector 임베딩 인프라
- `docker/docker-compose.*.yml` — postgres:16 → pgvector/pgvector:pg16
- `packages/core/src/db/types/vector.ts` — Drizzle vector384 customType
- `packages/core/src/db/schema/collections.ts` — articles/comments에 embedding 컬럼
- `packages/core/src/db/migrations/` — pgvector 확장 활성화 + HNSW 인덱스 SQL
- `packages/core/src/analysis/preprocessing/embedding-persist.ts` — 임베딩 persist 모듈
- `packages/core/src/queue/pipeline-worker.ts` — persist 단계에서 비차단 임베딩 생성
- `packages/core/src/scripts/backfill-embeddings.ts` — 기존 데이터 백필 스크립트

### 모델 설정
- `apps/web/src/components/settings/model-settings.tsx` — 모듈별 모델 설정 UI 대폭 개선
- `packages/core/src/analysis/model-config.ts` — MODULE_MODEL_MAP 확장

## 서버 배포 상태

서버 DB에 pgvector 확장, embedding 컬럼, HNSW 인덱스 **이미 적용 완료** (수동 SQL 실행)

## Test plan

- [x] `pnpm build` 전체 패키지 빌드 통과
- [x] TypeScript 타입 체크 통과
- [x] ESLint 통과 (lint-staged)
- [x] 서버 pgvector 확장 활성화 확인
- [x] 서버 embedding 컬럼 + HNSW 인덱스 생성 확인
- [ ] 수집 Job 실행 후 임베딩 자동 생성 확인 (merge 후)
- [ ] 백필 스크립트로 기존 데이터 임베딩 생성 (merge 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
