### PR TITLE
feat: 파이프라인 진단 모달 및 도메인 모듈 프롬프트 완성

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/components/analysis/job-diagnostic-modal.tsx
+++ b/apps/web/src/components/analysis/job-diagnostic-modal.tsx
@@ -1,0 +1,468 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Wrench,
+  RefreshCw,
+  Loader2,
+  Database,
+  Cpu,
+  AlertTriangle,
+  Info,
+  RotateCcw,
+  Trash2,
+  ArrowRight,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { MODULE_LABELS } from './pipeline-monitor/constants';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { trpcClient } from '@/lib/trpc';
+
+// ─── 파이프라인 흐름 시각화 ───────────────────────────────────────────────────
+
+const PIPELINE_STAGES = [
+  {
+    key: 'collection',
+    label: '수집',
+    desc: 'Playwright / YouTube API',
+    color: 'bg-blue-500',
+  },
+  {
+    key: 'normalize',
+    label: '정규화',
+    desc: 'DB 저장 · 중복제거',
+    color: 'bg-violet-500',
+  },
+  {
+    key: 'analysis',
+    label: 'AI 분석',
+    desc: 'BullMQ → 워커 → Claude/GPT',
+    color: 'bg-amber-500',
+  },
+  {
+    key: 'report',
+    label: '리포트',
+    desc: 'Markdown 생성',
+    color: 'bg-green-500',
+  },
+] as const;
+
+function PipelineFlowDiagram({ currentStage }: { currentStage: string | null }) {
+  return (
+    <div className="flex items-center gap-1 flex-wrap">
+      {PIPELINE_STAGES.map((stage, i) => {
+        const isActive = currentStage === stage.key;
+        const isDone = PIPELINE_STAGES.findIndex((s) => s.key === currentStage) > i;
+        return (
+          <div key={stage.key} className="flex items-center gap-1">
+            <div
+              className={`flex flex-col items-center px-3 py-1.5 rounded-md border text-xs transition-all ${
+                isActive
+                  ? `${stage.color} text-white border-transparent font-semibold shadow-md`
+                  : isDone
+                    ? 'bg-muted/60 text-muted-foreground border-border line-through'
+                    : 'bg-background text-muted-foreground border-border/60'
+              }`}
+            >
+              <span className="font-medium">{stage.label}</span>
+              <span className="text-[10px] opacity-70 mt-0.5">{stage.desc}</span>
+            </div>
+            {i < PIPELINE_STAGES.length - 1 && (
+              <ArrowRight className="h-3 w-3 text-muted-foreground/50 flex-shrink-0" />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── BullMQ 동작 원리 설명 ─────────────────────────────────────────────────
+
+function BullMQExplainer() {
+  return (
+    <div className="rounded-lg border bg-muted/30 p-3 text-xs space-y-2">
+      <div className="font-semibold text-sm flex items-center gap-1.5">
+        <Cpu className="h-4 w-4 text-amber-500" />
+        BullMQ 처리 원리
+      </div>
+      <div className="grid grid-cols-1 gap-1.5 text-muted-foreground">
+        <div className="flex items-start gap-2">
+          <span className="shrink-0 mt-0.5 text-[10px] font-mono bg-muted px-1 rounded">wait</span>
+          <span>큐에 추가됨. 워커가 여유 있을 때 꺼내감</span>
+        </div>
+        <div className="flex items-start gap-2">
+          <span className="shrink-0 mt-0.5 text-[10px] font-mono bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 px-1 rounded">
+            active
+          </span>
+          <span>워커가 처리 중. lock(10분) 내 갱신 필요</span>
+        </div>
+        <div className="flex items-start gap-2">
+          <span className="shrink-0 mt-0.5 text-[10px] font-mono bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400 px-1 rounded">
+            stalled
+          </span>
+          <span>
+            워커가 lock 갱신 실패 → 5분 후 stall 체크에서 감지. maxStalledCount(2) 초과 시 failed
+          </span>
+        </div>
+        <div className="flex items-start gap-2">
+          <span className="shrink-0 mt-0.5 text-[10px] font-mono bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 px-1 rounded">
+            completed
+          </span>
+          <span>정상 완료. 1시간 후 자동 삭제</span>
+        </div>
+      </div>
+      <div className="border-t pt-2 text-muted-foreground">
+        <span className="font-medium text-foreground">주요 원인:</span> 워커 프로세스 종료 / AI API
+        타임아웃 / lock 갱신 실패 → DB는 running, BullMQ는 없음 (고아 상태)
+      </div>
+    </div>
+  );
+}
+
+// ─── 문제 배지 ──────────────────────────────────────────────────────────────
+
+const ISSUE_ICON = {
+  error: AlertCircle,
+  warning: AlertTriangle,
+  info: CheckCircle2,
+};
+const ISSUE_CLASS = {
+  error: 'text-destructive bg-destructive/10 border-destructive/30',
+  warning:
+    'text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 border-amber-500/30',
+  info: 'text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-950/30 border-green-500/30',
+};
+
+function IssueCard({
+  issue,
+}: {
+  issue: { type: string; message: string; severity: 'error' | 'warning' | 'info' };
+}) {
+  const Icon = ISSUE_ICON[issue.severity];
+  return (
+    <div
+      className={`flex items-start gap-2 rounded-md border p-2.5 text-xs ${ISSUE_CLASS[issue.severity]}`}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+      <span>{issue.message}</span>
+    </div>
+  );
+}
+
+// ─── 모듈 상태 행 ──────────────────────────────────────────────────────────
+
+const MODULE_STATUS_CLASS: Record<string, string> = {
+  completed: 'text-green-600 dark:text-green-400',
+  running: 'text-amber-600 dark:text-amber-400',
+  pending: 'text-muted-foreground',
+  failed: 'text-destructive',
+};
+
+// ─── 메인 모달 내용 ────────────────────────────────────────────────────────
+
+function DiagnosticContent({ jobId }: { jobId: number }) {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, refetch, isFetching } = useQuery({
+    queryKey: ['job-diagnostic', jobId],
+    queryFn: () => trpcClient.pipeline.jobDiagnostic.query({ jobId }),
+    refetchInterval: false,
+    staleTime: 0,
+  });
+
+  const retryMutation = useMutation({
+    mutationFn: () =>
+      trpcClient.analysis.retryAnalysis.mutate({
+        jobId,
+        retryModules:
+          data?.dbModules
+            .filter(
+              (m) => m.status === 'running' || m.status === 'failed' || m.status === 'pending',
+            )
+            .map((m) => m.module) ?? [],
+      }),
+    onSuccess: () => {
+      toast.success('재실행 큐에 추가됐습니다');
+      queryClient.invalidateQueries({ queryKey: ['job-diagnostic', jobId] });
+    },
+    onError: () => toast.error('재실행 실패'),
+  });
+
+  const cleanupMutation = useMutation({
+    mutationFn: () => trpcClient.pipeline.forceCleanupJob.mutate({ jobId }),
+    onSuccess: (res) => {
+      toast.success(`고아 job ${res.cleaned}개 제거됨`);
+      refetch();
+    },
+    onError: () => toast.error('정리 실패'),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!data || !data.dbJob) {
+    return (
+      <div className="text-center py-8 text-muted-foreground text-sm">
+        job 정보를 찾을 수 없습니다.
+      </div>
+    );
+  }
+
+  const { dbJob, dbModules, bullmqJobs, issues } = data;
+  const hasErrors = issues.some((i) => i.severity === 'error');
+  const hasWarnings = issues.some((i) => i.severity === 'warning');
+
+  // 현재 파이프라인 단계 계산
+  const pipelineStageKey =
+    dbJob.status === 'collecting'
+      ? 'collection'
+      : dbJob.status === 'normalizing'
+        ? 'normalize'
+        : dbJob.status === 'analysing'
+          ? 'analysis'
+          : dbJob.status === 'reporting'
+            ? 'report'
+            : null;
+
+  // 재실행 가능한 모듈
+  const retriableModules = dbModules.filter(
+    (m) => m.status === 'running' || m.status === 'failed' || m.status === 'pending',
+  );
+  const hasOrphanedRunning =
+    dbModules.some((m) => m.status === 'running') && !bullmqJobs.some((j) => j.state === 'active');
+
+  return (
+    <div className="space-y-4 text-sm">
+      {/* 파이프라인 흐름 */}
+      <div className="space-y-1.5">
+        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          파이프라인 흐름
+        </div>
+        <PipelineFlowDiagram currentStage={pipelineStageKey} />
+      </div>
+
+      {/* BullMQ 설명 */}
+      <BullMQExplainer />
+
+      {/* 감지된 문제 */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            진단 결과
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 text-xs gap-1"
+            onClick={() => refetch()}
+            disabled={isFetching}
+          >
+            {isFetching ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3" />
+            )}
+            새로고침
+          </Button>
+        </div>
+        {issues.map((issue, i) => (
+          <IssueCard key={i} issue={issue} />
+        ))}
+      </div>
+
+      {/* DB 상태 vs BullMQ 상태 비교 */}
+      <div className="grid grid-cols-2 gap-3">
+        {/* DB 모듈 상태 */}
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            <Database className="h-3 w-3" />
+            DB 모듈 상태
+          </div>
+          <div className="rounded-md border divide-y">
+            {dbModules.length === 0 ? (
+              <div className="px-3 py-2 text-xs text-muted-foreground">분석 결과 없음</div>
+            ) : (
+              dbModules.map((m) => (
+                <div key={m.module} className="flex items-center justify-between px-3 py-1.5">
+                  <span className="text-xs">{MODULE_LABELS[m.module] ?? m.module}</span>
+                  <span
+                    className={`text-[11px] font-medium ${MODULE_STATUS_CLASS[m.status] ?? ''}`}
+                  >
+                    {m.status}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* BullMQ 큐 상태 */}
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            <Cpu className="h-3 w-3" />
+            BullMQ 큐 상태
+          </div>
+          <div className="rounded-md border divide-y">
+            {bullmqJobs.length === 0 ? (
+              <div className="px-3 py-2 text-xs text-muted-foreground">큐에 job 없음</div>
+            ) : (
+              bullmqJobs.map((j) => (
+                <div key={j.id} className="px-3 py-1.5 space-y-0.5">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-mono text-muted-foreground">{j.queue}</span>
+                    <Badge
+                      variant={
+                        j.state === 'active'
+                          ? 'secondary'
+                          : j.state === 'failed'
+                            ? 'destructive'
+                            : 'outline'
+                      }
+                      className="text-[10px] px-1 py-0 h-4"
+                    >
+                      {j.isStalled ? '⚠ stalled' : j.state}
+                    </Badge>
+                  </div>
+                  {j.elapsedMs != null && (
+                    <div className="text-[10px] text-muted-foreground">
+                      경과: {Math.round(j.elapsedMs / 1000)}초
+                    </div>
+                  )}
+                  {j.failedReason && (
+                    <div className="text-[10px] text-destructive truncate">{j.failedReason}</div>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* DB job 기본 정보 */}
+      <div className="rounded-md border p-3 space-y-1 text-xs">
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">Job ID</span>
+          <span className="font-mono font-medium">#{dbJob.id}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">키워드</span>
+          <span className="font-medium">{dbJob.keyword}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">상태</span>
+          <Badge variant="outline" className="text-[11px] h-4 px-1.5">
+            {dbJob.status}
+          </Badge>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">도메인</span>
+          <span>{dbJob.domain}</span>
+        </div>
+      </div>
+
+      {/* 액션 버튼 */}
+      <div className="flex flex-wrap gap-2 pt-1 border-t">
+        {/* 고아 active job 강제 제거 */}
+        {(hasErrors || bullmqJobs.some((j) => j.state === 'active')) && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1 text-xs"
+            onClick={() => cleanupMutation.mutate()}
+            disabled={cleanupMutation.isPending}
+          >
+            {cleanupMutation.isPending ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <Trash2 className="h-3 w-3" />
+            )}
+            고아 job 정리
+          </Button>
+        )}
+
+        {/* 실패/stuck 모듈 재실행 */}
+        {retriableModules.length > 0 && (
+          <Button
+            size="sm"
+            className="h-7 gap-1 text-xs"
+            onClick={() => retryMutation.mutate()}
+            disabled={retryMutation.isPending || (hasOrphanedRunning && !cleanupMutation.isSuccess)}
+          >
+            {retryMutation.isPending ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RotateCcw className="h-3 w-3" />
+            )}
+            {retriableModules.length}개 모듈 재실행
+          </Button>
+        )}
+
+        {hasOrphanedRunning && !cleanupMutation.isSuccess && (
+          <div className="flex items-center gap-1 text-[11px] text-amber-600 dark:text-amber-400">
+            <AlertTriangle className="h-3 w-3" />
+            고아 job 정리 후 재실행 권장
+          </div>
+        )}
+
+        {!hasErrors && !hasWarnings && retriableModules.length === 0 && (
+          <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+            <Info className="h-3 w-3" />
+            조치 불필요
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── 외부 노출 컴포넌트 ────────────────────────────────────────────────────
+
+interface JobDiagnosticModalProps {
+  jobId: number;
+  keyword: string;
+}
+
+export function JobDiagnosticModal({ jobId, keyword }: JobDiagnosticModalProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <span
+        role="button"
+        tabIndex={0}
+        className="inline-flex items-center justify-center h-5 w-5 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground cursor-pointer"
+        title="진단 / 상태 확인"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(true);
+        }}
+        onKeyDown={(e) => e.key === 'Enter' && setOpen(true)}
+      >
+        <Wrench className="h-3 w-3" />
+      </span>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Wrench className="h-4 w-4" />
+              Job #{jobId} 진단
+              <span className="text-muted-foreground font-normal text-sm">— {keyword}</span>
+            </DialogTitle>
+          </DialogHeader>
+          {open && <DiagnosticContent jobId={jobId} />}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/analysis/job-diagnostic-modal.tsx
+++ b/apps/web/src/components/analysis/job-diagnostic-modal.tsx
@@ -223,17 +223,17 @@ function DiagnosticContent({ jobId }: { jobId: number }) {
   const hasErrors = issues.some((i) => i.severity === 'error');
   const hasWarnings = issues.some((i) => i.severity === 'warning');
 
-  // 현재 파이프라인 단계 계산
-  const pipelineStageKey =
-    dbJob.status === 'collecting'
-      ? 'collection'
-      : dbJob.status === 'normalizing'
-        ? 'normalize'
-        : dbJob.status === 'analysing'
+  // 현재 파이프라인 단계 계산 (BullMQ 큐 이름 기준)
+  const activeQueues = bullmqJobs.filter((j) => j.state === 'active').map((j) => j.queue);
+  const pipelineStageKey = activeQueues.includes('collectors')
+    ? 'collection'
+    : activeQueues.includes('pipeline')
+      ? 'normalize'
+      : activeQueues.includes('analysis')
+        ? 'analysis'
+        : dbJob.status === 'running'
           ? 'analysis'
-          : dbJob.status === 'reporting'
-            ? 'report'
-            : null;
+          : null;
 
   // 재실행 가능한 모듈
   const retriableModules = dbModules.filter(

--- a/apps/web/src/components/analysis/recent-jobs.tsx
+++ b/apps/web/src/components/analysis/recent-jobs.tsx
@@ -6,6 +6,7 @@ import { format } from 'date-fns';
 import { CalendarRange, Clock, FileText, MessageSquare, Star } from 'lucide-react';
 import { SourceBadges, extractSources, summarizeCounts, formatDuration } from './source-icons';
 import { DomainBadge } from './domain-badge';
+import { JobDiagnosticModal } from './job-diagnostic-modal';
 import { trpcClient } from '@/lib/trpc';
 import type { FilterMode } from '@/components/filter-mode-toggle';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -143,6 +144,7 @@ export function RecentJobs({ onSelectJob, onSelectShowcase }: RecentJobsProps) {
                       <div className="flex items-center gap-1.5">
                         <span className="font-medium">{job.keyword}</span>
                         <DomainBadge domain={(job as any).domain} size="xs" />
+                        <JobDiagnosticModal jobId={job.id} keyword={job.keyword} />
                       </div>
                     </TableCell>
                     <TableCell>

--- a/apps/web/src/server/trpc/routers/pipeline.ts
+++ b/apps/web/src/server/trpc/routers/pipeline.ts
@@ -6,6 +6,8 @@ import {
   setSkippedModules,
   setCostLimit,
   getQueueStatus,
+  getJobDiagnostic,
+  forceCleanupActiveJob,
 } from '@ai-signalcraft/core';
 import { TRPCError } from '@trpc/server';
 import { getPipelineStatus } from '../../pipeline-status';
@@ -66,6 +68,23 @@ export const pipelineRouter = router({
   queueStatus: systemAdminProcedure.query(async () => {
     return getQueueStatus();
   }),
+
+  // 특정 job 진단 — DB/BullMQ 상태 비교 + 문제 감지
+  jobDiagnostic: protectedProcedure
+    .input(z.object({ jobId: z.number() }))
+    .query(async ({ input, ctx }) => {
+      await verifyJobOwnership(ctx, input.jobId, ctx.defaultFilterMode);
+      return getJobDiagnostic(input.jobId);
+    }),
+
+  // 고아 active job 강제 제거 + running 모듈 pending 초기화
+  forceCleanupJob: protectedProcedure
+    .input(z.object({ jobId: z.number() }))
+    .mutation(async ({ input, ctx }) => {
+      await verifyJobOwnership(ctx, input.jobId, ctx.defaultFilterMode);
+      const cleaned = await forceCleanupActiveJob(input.jobId);
+      return { cleaned };
+    }),
 
   // 비용 한도 설정
   setCostLimit: protectedProcedure

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -77,7 +77,7 @@ services:
     image: redis:7
     container_name: ais-prod-redis
     restart: unless-stopped
-    command: redis-server --maxmemory 512mb --maxmemory-policy noeviction --appendonly yes
+    command: redis-server --maxmemory 1gb --maxmemory-policy noeviction --appendonly yes
     ports:
       - "6385:6379"
     volumes:

--- a/packages/core/src/pipeline/control.ts
+++ b/packages/core/src/pipeline/control.ts
@@ -18,6 +18,8 @@ export {
   getQueueStatus,
   purgeAllBullMQJobs,
   cleanupBeforeNewPipeline,
+  getJobDiagnostic,
+  forceCleanupActiveJob,
 } from './queue-management';
 
 /**

--- a/packages/core/src/pipeline/queue-management.ts
+++ b/packages/core/src/pipeline/queue-management.ts
@@ -162,7 +162,7 @@ export async function forceCleanupActiveJob(dbJobId: number): Promise<number> {
   for (const queueName of ['collectors', 'pipeline', 'analysis']) {
     const queue = getQueue(queueName);
     try {
-      const activeJobs = await queue.getJobs(['active', 'stalled']);
+      const activeJobs = await queue.getJobs(['active', 'waiting']);
       for (const job of activeJobs) {
         if (job.data?.dbJobId !== dbJobId) continue;
         try {
@@ -218,7 +218,7 @@ export async function getJobDiagnostic(dbJobId: number) {
   for (const queueName of ['collectors', 'pipeline', 'analysis']) {
     const queue = getQueue(queueName);
     try {
-      const jobs = await queue.getJobs(['active', 'waiting', 'delayed', 'failed', 'stalled']);
+      const jobs = await queue.getJobs(['active', 'waiting', 'delayed', 'failed']);
       for (const job of jobs) {
         if (job.data?.dbJobId !== dbJobId) continue;
         let state = 'unknown';

--- a/packages/core/src/pipeline/queue-management.ts
+++ b/packages/core/src/pipeline/queue-management.ts
@@ -3,6 +3,7 @@ import { Queue } from 'bullmq';
 import { eq } from 'drizzle-orm';
 import { getDb } from '../db';
 import { collectionJobs } from '../db/schema/collections';
+import { analysisResults } from '../db/schema/analysis';
 import { getBullMQOptions } from '../queue/connection';
 
 let _collectors: Queue | null = null;
@@ -116,15 +117,17 @@ export async function purgeAllBullMQJobs(jobId: number): Promise<number> {
   return removeWaitingBullMQJobs(jobId);
 }
 
-/** 새 파이프라인 실행 전 이전 잔여 작업 전체 정리 */
+/** 새 파이프라인 실행 전 이전 잔여 작업 전체 정리 (active 포함 — stalled 고아 제거) */
 export async function cleanupBeforeNewPipeline(): Promise<number> {
   const db = getDb();
   let cleaned = 0;
+  const TERMINAL_STATUSES = ['cancelled', 'failed', 'completed'];
 
   for (const queueName of ['collectors', 'pipeline', 'analysis']) {
     const queue = getQueue(queueName);
     try {
-      const jobs = await queue.getJobs(['waiting', 'delayed', 'waiting-children']);
+      // waiting/delayed/waiting-children + active 모두 검사
+      const jobs = await queue.getJobs(['waiting', 'delayed', 'waiting-children', 'active']);
       for (const job of jobs) {
         if (!job?.data?.dbJobId) continue;
 
@@ -134,7 +137,7 @@ export async function cleanupBeforeNewPipeline(): Promise<number> {
           .where(eq(collectionJobs.id, job.data.dbJobId))
           .limit(1);
 
-        const shouldRemove = !dbJob || dbJob.status === 'cancelled' || dbJob.status === 'failed';
+        const shouldRemove = !dbJob || TERMINAL_STATUSES.includes(dbJob.status);
         if (!shouldRemove) continue;
 
         try {
@@ -150,4 +153,150 @@ export async function cleanupBeforeNewPipeline(): Promise<number> {
   }
 
   return cleaned;
+}
+
+/** 특정 job의 BullMQ 고아 active job을 강제 제거 */
+export async function forceCleanupActiveJob(dbJobId: number): Promise<number> {
+  let cleaned = 0;
+
+  for (const queueName of ['collectors', 'pipeline', 'analysis']) {
+    const queue = getQueue(queueName);
+    try {
+      const activeJobs = await queue.getJobs(['active', 'stalled']);
+      for (const job of activeJobs) {
+        if (job.data?.dbJobId !== dbJobId) continue;
+        try {
+          await job.remove();
+          cleaned++;
+        } catch {
+          /* 이미 상태 변경됨 */
+        }
+      }
+    } catch {
+      // 큐 접근 실패
+    }
+  }
+
+  return cleaned;
+}
+
+/** 특정 job의 BullMQ 상태 + DB 상태 진단 */
+export async function getJobDiagnostic(dbJobId: number) {
+  const db = getDb();
+  const now = Date.now();
+  const LOCK_DURATION = 600_000; // analysis-worker의 lockDuration
+
+  // DB 상태 조회
+  const [dbJob] = await db
+    .select()
+    .from(collectionJobs)
+    .where(eq(collectionJobs.id, dbJobId))
+    .limit(1);
+
+  const dbModules = await db
+    .select({
+      module: analysisResults.module,
+      status: analysisResults.status,
+      errorMessage: analysisResults.errorMessage,
+      updatedAt: analysisResults.updatedAt,
+    })
+    .from(analysisResults)
+    .where(eq(analysisResults.jobId, dbJobId));
+
+  // BullMQ 상태 조회
+  const bullmqJobs: Array<{
+    queue: string;
+    id: string;
+    name: string;
+    state: string;
+    processedOn: number | null;
+    failedReason: string | null;
+    isStalled: boolean;
+    elapsedMs: number | null;
+  }> = [];
+
+  for (const queueName of ['collectors', 'pipeline', 'analysis']) {
+    const queue = getQueue(queueName);
+    try {
+      const jobs = await queue.getJobs(['active', 'waiting', 'delayed', 'failed', 'stalled']);
+      for (const job of jobs) {
+        if (job.data?.dbJobId !== dbJobId) continue;
+        let state = 'unknown';
+        try {
+          state = await job.getState();
+        } catch {
+          /* ignore */
+        }
+        const elapsedMs = job.processedOn ? now - job.processedOn : null;
+        const isStalled =
+          state === 'active' && elapsedMs !== null && elapsedMs > LOCK_DURATION * 1.2;
+        bullmqJobs.push({
+          queue: queueName,
+          id: job.id ?? '',
+          name: job.name,
+          state,
+          processedOn: job.processedOn ?? null,
+          failedReason: job.failedReason ?? null,
+          isStalled,
+          elapsedMs,
+        });
+      }
+    } catch {
+      // 큐 접근 실패
+    }
+  }
+
+  // 문제 감지
+  const issues: Array<{ type: string; message: string; severity: 'error' | 'warning' | 'info' }> =
+    [];
+
+  // DB running 모듈인데 BullMQ active job 없음 → 고아 상태
+  const runningModules = dbModules.filter((m) => m.status === 'running');
+  const hasActiveBullMQJob = bullmqJobs.some((j) => j.state === 'active');
+  if (runningModules.length > 0 && !hasActiveBullMQJob) {
+    issues.push({
+      type: 'orphaned_running',
+      message: `DB에 running 모듈 ${runningModules.length}개가 있으나 BullMQ active job이 없습니다. 워커가 종료되어 고아 상태입니다.`,
+      severity: 'error',
+    });
+  }
+
+  // BullMQ active job이 lock 만료 시간을 초과한 경우
+  const stalledJobs = bullmqJobs.filter((j) => j.isStalled);
+  if (stalledJobs.length > 0) {
+    issues.push({
+      type: 'lock_expired',
+      message: `BullMQ active job이 lock 만료 시간(${LOCK_DURATION / 60000}분)을 초과했습니다. stalled 처리 예정입니다.`,
+      severity: 'warning',
+    });
+  }
+
+  // DB completed인데 BullMQ active 잔류
+  if (dbJob?.status && ['cancelled', 'failed', 'completed'].includes(dbJob.status)) {
+    const orphanActive = bullmqJobs.filter((j) => j.state === 'active');
+    if (orphanActive.length > 0) {
+      issues.push({
+        type: 'zombie_active',
+        message: `DB job이 ${dbJob.status} 상태인데 BullMQ에 active job ${orphanActive.length}개가 남아있습니다.`,
+        severity: 'error',
+      });
+    }
+  }
+
+  // 모두 정상
+  if (issues.length === 0 && dbJob) {
+    issues.push({
+      type: 'ok',
+      message: '정상 상태입니다.',
+      severity: 'info',
+    });
+  }
+
+  return {
+    dbJob: dbJob ?? null,
+    dbModules,
+    bullmqJobs,
+    issues,
+    checkedAt: now,
+  };
 }

--- a/packages/core/src/queue/analysis-worker.ts
+++ b/packages/core/src/queue/analysis-worker.ts
@@ -91,6 +91,8 @@ export function createAnalysisWorker(): Worker {
       // AI 분석은 수분~수십분 소요 — 기본 30초 lockDuration은 stall 발생
       lockDuration: 600_000, // 10분
       stalledInterval: 300_000, // 5분마다 stall check
+      maxStalledCount: 2, // stall 발생 시 2회까지 자동 재시도 (기본 0 = 즉시 failed)
+      streams: { events: { maxLen: 500 } }, // event stream 무한 누적 방지
     },
   );
 }

--- a/packages/core/src/queue/analysis-worker.ts
+++ b/packages/core/src/queue/analysis-worker.ts
@@ -92,7 +92,6 @@ export function createAnalysisWorker(): Worker {
       lockDuration: 600_000, // 10분
       stalledInterval: 300_000, // 5분마다 stall check
       maxStalledCount: 2, // stall 발생 시 2회까지 자동 재시도 (기본 0 = 즉시 failed)
-      streams: { events: { maxLen: 500 } }, // event stream 무한 누적 방지
     },
   );
 }

--- a/packages/core/src/queue/workers.ts
+++ b/packages/core/src/queue/workers.ts
@@ -16,6 +16,7 @@ export function createCollectorWorker(processJob: (job: Job) => Promise<any>) {
     lockDuration: 600_000, // 10분
     stalledInterval: 300_000, // 5분마다 stall check
     maxStalledCount: 2,
+    streams: { events: { maxLen: 500 } }, // event stream 무한 누적 방지
   });
 }
 
@@ -27,5 +28,6 @@ export function createPipelineWorker(processJob: (job: Job) => Promise<any>) {
     lockDuration: 600_000,
     stalledInterval: 300_000,
     maxStalledCount: 2,
+    streams: { events: { maxLen: 500 } }, // event stream 무한 누적 방지
   });
 }

--- a/packages/core/src/queue/workers.ts
+++ b/packages/core/src/queue/workers.ts
@@ -16,7 +16,6 @@ export function createCollectorWorker(processJob: (job: Job) => Promise<any>) {
     lockDuration: 600_000, // 10분
     stalledInterval: 300_000, // 5분마다 stall check
     maxStalledCount: 2,
-    streams: { events: { maxLen: 500 } }, // event stream 무한 누적 방지
   });
 }
 
@@ -28,6 +27,5 @@ export function createPipelineWorker(processJob: (job: Job) => Promise<any>) {
     lockDuration: 600_000,
     stalledInterval: 300_000,
     maxStalledCount: 2,
-    streams: { events: { maxLen: 500 } }, // event stream 무한 누적 방지
   });
 }


### PR DESCRIPTION
## Summary

- 12개 도메인 modulePrompts 완성
- 기업 평판 모듈 모델 변경
- 잡 진단 모달 추가 (파이프라인 흐름 시각화, 모듈 상태, BullMQ 상태)
- 파이프라인 컨트롤/큐 관리 로직 개선
- 분석 워커 설정 업데이트

## Test plan

- [ ] 진단 모달 열기/닫기 동작 확인
- [ ] 파이프라인 상태 진단 표시 확인
- [ ] 재실행 기능 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)