### PR TITLE
fix: 키워드/지식 그래프 노드 간격 및 라벨 색상 개선

### DIFF
--- a/apps/web/src/components/dashboard/keyword-network-graph.tsx
+++ b/apps/web/src/components/dashboard/keyword-network-graph.tsx
@@ -55,12 +55,14 @@ export function KeywordNetworkGraph({
         d3
           .forceLink<SimNode, SimEdge>(links)
           .id((d) => d.id)
-          .distance(80)
-          .strength((d) => d.weight),
+          .distance(70)
+          .strength((d) => Math.max(d.weight, 0.3)),
       )
-      .force('charge', d3.forceManyBody().strength(-200))
-      .force('center', d3.forceCenter(width / 2, height / 2))
-      .force('collision', d3.forceCollide().radius(20));
+      .force('charge', d3.forceManyBody().strength(-120))
+      .force('center', d3.forceCenter(width / 2, height / 2).strength(0.12))
+      .force('collision', d3.forceCollide().radius(25))
+      .force('x', d3.forceX(width / 2).strength(0.04))
+      .force('y', d3.forceY(height / 2).strength(0.04));
 
     // 엣지
     const link = g
@@ -118,7 +120,7 @@ export function KeywordNetworkGraph({
       .attr('font-weight', 600)
       .attr('dx', (d) => Math.max(Math.sqrt(d.size) * 3, 5) + 6)
       .attr('dy', 4)
-      .attr('class', 'fill-foreground')
+      .attr('class', 'fill-muted-foreground')
       .attr('paint-order', 'stroke')
       .attr('style', 'stroke: var(--color-card); stroke-width: 3.5px; stroke-linejoin: round;')
       .attr('pointer-events', 'none');

--- a/apps/web/src/components/dashboard/knowledge-graph-view.tsx
+++ b/apps/web/src/components/dashboard/knowledge-graph-view.tsx
@@ -113,12 +113,14 @@ export function KnowledgeGraphView({ data, isLoading }: KnowledgeGraphViewProps)
         d3
           .forceLink<SimNode, SimEdge>(links)
           .id((d) => d.id)
-          .distance(100)
-          .strength((d) => d.weight * 0.6),
+          .distance(120)
+          .strength((d) => Math.max(d.weight * 0.4, 0.2)),
       )
-      .force('charge', d3.forceManyBody().strength(-250))
-      .force('center', d3.forceCenter(width / 2, height / 2))
-      .force('collision', d3.forceCollide().radius(20));
+      .force('charge', d3.forceManyBody().strength(-200))
+      .force('center', d3.forceCenter(width / 2, height / 2).strength(0.08))
+      .force('collision', d3.forceCollide().radius(35))
+      .force('x', d3.forceX(width / 2).strength(0.03))
+      .force('y', d3.forceY(height / 2).strength(0.03));
 
     // 엣지
     const link = g
@@ -201,7 +203,7 @@ export function KnowledgeGraphView({ data, isLoading }: KnowledgeGraphViewProps)
       .attr('font-weight', 600)
       .attr('text-anchor', 'middle')
       .attr('dy', (d) => Math.max(d.size * 0.5, 8) + 16)
-      .attr('class', 'fill-foreground')
+      .attr('class', 'fill-muted-foreground')
       .attr('paint-order', 'stroke')
       .attr('style', 'stroke: var(--color-card); stroke-width: 3.5px; stroke-linejoin: round;')
       .attr('pointer-events', 'none');


### PR DESCRIPTION
## Summary
- 키워드 네트워크, 지식 그래프 D3 force 파라미터 조정으로 노드 간격 개선
- `forceX/Y` 추가로 고립 노드(엣지 없는 노드)도 중앙으로 수렴
- 노드 라벨 색상을 `fill-muted-foreground`로 변경해 가독성 향상

## Test plan
- [ ] 결과 대시보드 > 키워드 네트워크 레이아웃 확인
- [ ] 결과 대시보드 > 지식 그래프 레이아웃 확인
- [ ] 노드 간격이 적절하고 겹치지 않는지 확인
- [ ] 라벨 색상이 흐리게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)