### PR TITLE
feat: 토큰 최적화 기본값 RAG 표준으로 변경 및 도움말 툴팁 추가

### DIFF
--- a/apps/web/src/components/analysis/trigger-form.tsx
+++ b/apps/web/src/components/analysis/trigger-form.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
 import { toast } from 'sonner';
-import { Loader2, ChevronDown, Lock } from 'lucide-react';
+import { Loader2, ChevronDown, Lock, HelpCircle } from 'lucide-react';
 import { format, subDays, addDays } from 'date-fns';
 import { TriggerFormHelp } from './trigger-form-help';
 import { DomainBadge } from './domain-badge';
@@ -26,6 +26,7 @@ import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
 
 interface TriggerFormProps {
   onJobStarted: (jobId: number) => void;
@@ -512,6 +513,17 @@ export function TriggerForm({ onJobStarted, preset, onChangePreset }: TriggerFor
             <CollapsibleTrigger className="w-full flex items-center justify-between rounded-lg border px-3 py-2 text-sm hover:bg-accent transition-colors cursor-pointer">
               <div className="flex items-center gap-2">
                 <span className="font-medium">수집 한도 & 토큰 최적화</span>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger onClick={(e) => e.stopPropagation()} className="cursor-help">
+                      <HelpCircle className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
+                    </TooltipTrigger>
+                    <TooltipContent side="right" className="max-w-[220px] text-center">
+                      수집할 데이터 양과 AI 처리 전략을 설정합니다. 값을 줄이면 분석 비용과 시간이
+                      절감됩니다.
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
                 {optimizationPreset !== 'none' && (
                   <span
                     className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${PRESET_STYLES[optimizationPreset]?.indicator ?? 'bg-zinc-500/15 text-zinc-500'}`}
@@ -526,172 +538,244 @@ export function TriggerForm({ onJobStarted, preset, onChangePreset }: TriggerFor
               />
             </CollapsibleTrigger>
             <CollapsibleContent>
-              <div className="mt-2 space-y-3 rounded-lg border p-3">
-                <p className="text-xs text-muted-foreground">
-                  소스별 최대 수집 건수를 조절합니다. 줄이면 비용과 시간이 절약됩니다.
-                </p>
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-1">
-                    <Label htmlFor="maxNaver" className="text-xs">
-                      네이버 뉴스
-                    </Label>
-                    <Input
-                      id="maxNaver"
-                      type="number"
-                      min={10}
-                      max={5000}
-                      step={10}
-                      value={maxNaverArticles}
-                      onChange={(e) => setMaxNaverArticles(Number(e.target.value))}
-                      disabled={triggerMutation.isPending}
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <Label htmlFor="maxYoutube" className="text-xs">
-                      유튜브 영상
-                    </Label>
-                    <Input
-                      id="maxYoutube"
-                      type="number"
-                      min={5}
-                      max={500}
-                      step={5}
-                      value={maxYoutubeVideos}
-                      onChange={(e) => setMaxYoutubeVideos(Number(e.target.value))}
-                      disabled={triggerMutation.isPending}
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <Label htmlFor="maxCommunity" className="text-xs">
-                      커뮤니티 게시글
-                    </Label>
-                    <Input
-                      id="maxCommunity"
-                      type="number"
-                      min={5}
-                      max={500}
-                      step={5}
-                      value={maxCommunityPosts}
-                      onChange={(e) => setMaxCommunityPosts(Number(e.target.value))}
-                      disabled={triggerMutation.isPending}
-                    />
-                  </div>
-                  <div className="space-y-1">
-                    <Label htmlFor="maxComments" className="text-xs">
-                      항목당 댓글
-                    </Label>
-                    <Input
-                      id="maxComments"
-                      type="number"
-                      min={10}
-                      max={2000}
-                      step={10}
-                      value={maxCommentsPerItem}
-                      onChange={(e) => setMaxCommentsPerItem(Number(e.target.value))}
-                      disabled={triggerMutation.isPending}
-                    />
-                  </div>
-                </div>
-
-                {/* 구분선 */}
-                <div className="border-t my-1" />
-
-                {/* 토큰 최적화 프리셋 */}
-                <div className="space-y-2">
-                  <Label className="text-xs">토큰 최적화</Label>
-                  {/* 기존 모드 */}
-                  <div className="grid grid-cols-4 gap-1.5">
-                    {(
-                      Object.entries(OPTIMIZATION_PRESETS).filter(
-                        ([, p]) => p.group === 'classic',
-                      ) as [OptimizationPreset, (typeof OPTIMIZATION_PRESETS)[OptimizationPreset]][]
-                    ).map(([key, preset]) => {
-                      const style = PRESET_STYLES[key];
-                      return (
-                        <button
-                          key={key}
-                          type="button"
-                          onClick={() => setOptimizationPreset(key)}
-                          disabled={triggerMutation.isPending}
-                          className={`rounded-md border p-2 text-center transition-colors ${
-                            optimizationPreset === key
-                              ? `${style?.border ?? 'border-zinc-500'} ${style?.bg ?? 'bg-zinc-500/10'}`
-                              : 'border-border hover:bg-accent'
-                          }`}
-                        >
-                          <div
-                            className={`text-xs font-medium ${
-                              optimizationPreset === key
-                                ? (style?.text ?? 'text-zinc-400')
-                                : 'text-muted-foreground'
-                            }`}
-                          >
-                            {preset.label}
-                          </div>
-                          {key !== 'none' && (
-                            <div className="text-[10px] text-muted-foreground mt-0.5">
-                              {preset.estimatedReduction}↓
-                            </div>
-                          )}
-                        </button>
-                      );
-                    })}
-                  </div>
-                  {/* RAG 모드 */}
-                  <div className="grid grid-cols-3 gap-1.5">
-                    {(
-                      Object.entries(OPTIMIZATION_PRESETS).filter(([, p]) => p.group === 'rag') as [
-                        OptimizationPreset,
-                        (typeof OPTIMIZATION_PRESETS)[OptimizationPreset],
-                      ][]
-                    ).map(([key, preset]) => {
-                      const style = PRESET_STYLES[key];
-                      return (
-                        <button
-                          key={key}
-                          type="button"
-                          onClick={() => setOptimizationPreset(key)}
-                          disabled={triggerMutation.isPending}
-                          className={`rounded-md border p-2 text-center transition-colors ${
-                            optimizationPreset === key
-                              ? `${style?.border} ${style?.bg}`
-                              : 'border-border hover:bg-accent'
-                          }`}
-                        >
-                          <div
-                            className={`text-xs font-medium ${
-                              optimizationPreset === key ? style?.text : 'text-muted-foreground'
-                            }`}
-                          >
-                            {preset.label}
-                          </div>
-                          <div className="text-[10px] text-muted-foreground mt-0.5">
-                            {preset.estimatedReduction}↓
-                          </div>
-                        </button>
-                      );
-                    })}
-                  </div>
-                  <p className="text-[10px] text-muted-foreground">
-                    RAG 모드는 DB에 저장된 임베딩을 활용하여 의미 관련 문서만 선별합니다.
+              <TooltipProvider>
+                <div className="mt-2 space-y-3 rounded-lg border p-3">
+                  <p className="text-xs text-muted-foreground">
+                    소스별 최대 수집 건수를 조절합니다. 줄이면 비용과 시간이 절약됩니다.
                   </p>
-                  {optimizationPreset !== 'none' && (
-                    <div
-                      className={`rounded-md p-2 text-xs border-l-2 ${
-                        PRESET_STYLES[optimizationPreset]?.border?.replace(
-                          'border-',
-                          'border-l-',
-                        ) ?? 'border-l-zinc-500'
-                      } ${
-                        PRESET_STYLES[optimizationPreset]?.bg?.replace('/10', '/5') ??
-                        'bg-zinc-500/5'
-                      }`}
-                    >
-                      {OPTIMIZATION_PRESETS[optimizationPreset].description}
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <Label htmlFor="maxNaver" className="text-xs flex items-center gap-1">
+                        네이버 뉴스
+                        <Tooltip>
+                          <TooltipTrigger className="cursor-help">
+                            <HelpCircle className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="max-w-[200px]">
+                            수집할 네이버 뉴스 기사의 최대 건수입니다. 키워드와 기간에 따라 실제
+                            수집량은 이보다 적을 수 있습니다. (범위: 10 ~ 5,000건)
+                          </TooltipContent>
+                        </Tooltip>
+                      </Label>
+                      <Input
+                        id="maxNaver"
+                        type="number"
+                        min={10}
+                        max={5000}
+                        step={10}
+                        value={maxNaverArticles}
+                        onChange={(e) => setMaxNaverArticles(Number(e.target.value))}
+                        disabled={triggerMutation.isPending}
+                      />
                     </div>
-                  )}
+                    <div className="space-y-1">
+                      <Label htmlFor="maxYoutube" className="text-xs flex items-center gap-1">
+                        유튜브 영상
+                        <Tooltip>
+                          <TooltipTrigger className="cursor-help">
+                            <HelpCircle className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="max-w-[200px]">
+                            수집할 유튜브 영상의 최대 건수입니다. 영상 제목·설명·댓글을 분석합니다.
+                            (범위: 5 ~ 500건)
+                          </TooltipContent>
+                        </Tooltip>
+                      </Label>
+                      <Input
+                        id="maxYoutube"
+                        type="number"
+                        min={5}
+                        max={500}
+                        step={5}
+                        value={maxYoutubeVideos}
+                        onChange={(e) => setMaxYoutubeVideos(Number(e.target.value))}
+                        disabled={triggerMutation.isPending}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label htmlFor="maxCommunity" className="text-xs flex items-center gap-1">
+                        커뮤니티 게시글
+                        <Tooltip>
+                          <TooltipTrigger className="cursor-help">
+                            <HelpCircle className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="max-w-[200px]">
+                            DC갤러리·에펨코리아·클리앙 등 선택한 커뮤니티에서 수집할 게시글
+                            수입니다. (범위: 5 ~ 500건)
+                          </TooltipContent>
+                        </Tooltip>
+                      </Label>
+                      <Input
+                        id="maxCommunity"
+                        type="number"
+                        min={5}
+                        max={500}
+                        step={5}
+                        value={maxCommunityPosts}
+                        onChange={(e) => setMaxCommunityPosts(Number(e.target.value))}
+                        disabled={triggerMutation.isPending}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label htmlFor="maxComments" className="text-xs flex items-center gap-1">
+                        항목당 댓글
+                        <Tooltip>
+                          <TooltipTrigger className="cursor-help">
+                            <HelpCircle className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="max-w-[200px]">
+                            각 기사/게시글/영상에서 수집할 댓글의 최대 건수입니다. 댓글은 AI 분석의
+                            주요 여론 신호입니다. (범위: 10 ~ 2,000건)
+                          </TooltipContent>
+                        </Tooltip>
+                      </Label>
+                      <Input
+                        id="maxComments"
+                        type="number"
+                        min={10}
+                        max={2000}
+                        step={10}
+                        value={maxCommentsPerItem}
+                        onChange={(e) => setMaxCommentsPerItem(Number(e.target.value))}
+                        disabled={triggerMutation.isPending}
+                      />
+                    </div>
+                  </div>
+
+                  {/* 구분선 */}
+                  <div className="border-t my-1" />
+
+                  {/* 토큰 최적화 프리셋 */}
+                  <div className="space-y-2">
+                    <Label className="text-xs flex items-center gap-1">
+                      토큰 최적화
+                      <Tooltip>
+                        <TooltipTrigger className="cursor-help">
+                          <HelpCircle className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="max-w-[220px]">
+                          수집된 데이터를 AI에 전달하기 전에 전처리하여 토큰(비용·속도)을 줄이는
+                          설정입니다. 높을수록 비용이 절감되지만 일부 데이터가 제외됩니다.
+                        </TooltipContent>
+                      </Tooltip>
+                    </Label>
+                    {/* 기존 모드 */}
+                    <div className="grid grid-cols-4 gap-1.5">
+                      {(
+                        Object.entries(OPTIMIZATION_PRESETS).filter(
+                          ([, p]) => p.group === 'classic',
+                        ) as [
+                          OptimizationPreset,
+                          (typeof OPTIMIZATION_PRESETS)[OptimizationPreset],
+                        ][]
+                      ).map(([key, preset]) => {
+                        const style = PRESET_STYLES[key];
+                        return (
+                          <Tooltip key={key}>
+                            <TooltipTrigger
+                              render={
+                                <button
+                                  type="button"
+                                  onClick={() => setOptimizationPreset(key)}
+                                  disabled={triggerMutation.isPending}
+                                  className={`rounded-md border p-2 text-center transition-colors w-full ${
+                                    optimizationPreset === key
+                                      ? `${style?.border ?? 'border-zinc-500'} ${style?.bg ?? 'bg-zinc-500/10'}`
+                                      : 'border-border hover:bg-accent'
+                                  }`}
+                                >
+                                  <div
+                                    className={`text-xs font-medium ${
+                                      optimizationPreset === key
+                                        ? (style?.text ?? 'text-zinc-400')
+                                        : 'text-muted-foreground'
+                                    }`}
+                                  >
+                                    {preset.label}
+                                  </div>
+                                  {key !== 'none' && (
+                                    <div className="text-[10px] text-muted-foreground mt-0.5">
+                                      {preset.estimatedReduction}↓
+                                    </div>
+                                  )}
+                                </button>
+                              }
+                            />
+                            <TooltipContent side="bottom" className="max-w-[180px]">
+                              {preset.description}
+                            </TooltipContent>
+                          </Tooltip>
+                        );
+                      })}
+                    </div>
+                    {/* RAG 모드 */}
+                    <div className="grid grid-cols-3 gap-1.5">
+                      {(
+                        Object.entries(OPTIMIZATION_PRESETS).filter(
+                          ([, p]) => p.group === 'rag',
+                        ) as [
+                          OptimizationPreset,
+                          (typeof OPTIMIZATION_PRESETS)[OptimizationPreset],
+                        ][]
+                      ).map(([key, preset]) => {
+                        const style = PRESET_STYLES[key];
+                        return (
+                          <Tooltip key={key}>
+                            <TooltipTrigger
+                              render={
+                                <button
+                                  type="button"
+                                  onClick={() => setOptimizationPreset(key)}
+                                  disabled={triggerMutation.isPending}
+                                  className={`rounded-md border p-2 text-center transition-colors w-full ${
+                                    optimizationPreset === key
+                                      ? `${style?.border} ${style?.bg}`
+                                      : 'border-border hover:bg-accent'
+                                  }`}
+                                >
+                                  <div
+                                    className={`text-xs font-medium ${
+                                      optimizationPreset === key
+                                        ? style?.text
+                                        : 'text-muted-foreground'
+                                    }`}
+                                  >
+                                    {preset.label}
+                                  </div>
+                                  <div className="text-[10px] text-muted-foreground mt-0.5">
+                                    {preset.estimatedReduction}↓
+                                  </div>
+                                </button>
+                              }
+                            />
+                            <TooltipContent side="bottom" className="max-w-[180px]">
+                              {preset.description}
+                            </TooltipContent>
+                          </Tooltip>
+                        );
+                      })}
+                    </div>
+                    <p className="text-[10px] text-muted-foreground">
+                      RAG 모드는 DB에 저장된 임베딩을 활용하여 의미 관련 문서만 선별합니다.
+                    </p>
+                    {optimizationPreset !== 'none' && (
+                      <div
+                        className={`rounded-md p-2 text-xs border-l-2 ${
+                          PRESET_STYLES[optimizationPreset]?.border?.replace(
+                            'border-',
+                            'border-l-',
+                          ) ?? 'border-l-zinc-500'
+                        } ${
+                          PRESET_STYLES[optimizationPreset]?.bg?.replace('/10', '/5') ??
+                          'bg-zinc-500/5'
+                        }`}
+                      >
+                        {OPTIMIZATION_PRESETS[optimizationPreset].description}
+                      </div>
+                    )}
+                  </div>
                 </div>
-              </div>
+              </TooltipProvider>
             </CollapsibleContent>
           </Collapsible>
 

--- a/packages/core/src/db/schema/presets.ts
+++ b/packages/core/src/db/schema/presets.ts
@@ -30,10 +30,18 @@ export const analysisPresets = pgTable(
       commentsPerItem: number;
     }>(),
     optimization: text('optimization', {
-      enum: ['none', 'light', 'standard', 'aggressive'],
+      enum: [
+        'none',
+        'light',
+        'standard',
+        'aggressive',
+        'rag-light',
+        'rag-standard',
+        'rag-aggressive',
+      ],
     })
       .notNull()
-      .default('standard'),
+      .default('rag-standard'),
     skippedModules: jsonb('skipped_modules').notNull().$type<string[]>().default([]),
     enableItemAnalysis: boolean('enable_item_analysis').notNull().default(false),
     enabled: boolean('enabled').notNull().default(true),


### PR DESCRIPTION
## Summary

- `analysis_presets` 스키마 `optimization` enum에 RAG 값 3개(`rag-light`, `rag-standard`, `rag-aggressive`) 추가 및 기본값 `standard` → `rag-standard` 변경
- DB 기존 프리셋 12개 `optimization` 값 마이그레이션 (`standard` → `rag-standard`, `light` → `rag-light`)
- 수집 한도 & 토큰 최적화 섹션에 HelpCircle 툴팁 도움말 추가 (섹션 제목, 수집 한도 라벨 4개, 토큰 최적화 라벨, 프리셋 버튼 7개)

## Test plan

- [ ] 분석 실행 폼 접속 시 "수집 한도 & 토큰 최적화" 섹션 뱃지가 `RAG 표준 ~65%↓`로 표시되는지 확인
- [ ] 섹션 펼쳤을 때 각 라벨의 `?` 아이콘 hover 시 툴팁 표시 확인
- [ ] 프리셋 버튼 7개 hover 시 상세 설명 툴팁 표시 확인
- [ ] 프리셋 선택 후 변경이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)