### PR TITLE
fix: 개별 기사/댓글 감정 분석 옵션 기본값 활성화

### DIFF
--- a/apps/web/src/components/analysis/trigger-form.tsx
+++ b/apps/web/src/components/analysis/trigger-form.tsx
@@ -86,7 +86,7 @@ export function TriggerForm({ onJobStarted, preset, onChangePreset }: TriggerFor
   const [helpTab, setHelpTab] = useState('quickstart');
   const [startDate, setStartDate] = useState<Date>(STABLE_INIT_DATE);
   const [endDate, setEndDate] = useState<Date>(STABLE_INIT_DATE);
-  const [enableItemAnalysis, setEnableItemAnalysis] = useState(isDemo);
+  const [enableItemAnalysis, setEnableItemAnalysis] = useState(true);
   const [dateMode, setDateMode] = useState<'period' | 'event'>('period');
   const [eventName, setEventName] = useState('');
   const [eventDate, setEventDate] = useState<Date>(STABLE_INIT_DATE);
@@ -138,7 +138,7 @@ export function TriggerForm({ onJobStarted, preset, onChangePreset }: TriggerFor
     setMaxCommunityPosts(preset.limits.communityPosts);
     setMaxCommentsPerItem(preset.limits.commentsPerItem);
     setOptimizationPreset(preset.optimization);
-    setEnableItemAnalysis(preset.enableItemAnalysis);
+    setEnableItemAnalysis(true);
   }, [preset]);
 
   const triggerMutation = useMutation({


### PR DESCRIPTION
## Summary
- `enableItemAnalysis` 초기값을 `isDemo`에서 `true`로 변경하여 항상 체크된 상태로 표시
- 프리셋 적용 시 프리셋의 `enableItemAnalysis` 값과 무관하게 항상 `true`로 유지

## Test plan
- [ ] 분석 실행 폼 진입 시 "개별 기사/댓글 감정 분석" 체크박스가 기본으로 체크되어 있는지 확인
- [ ] 프리셋 변경 시에도 체크 상태가 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)