### PR TITLE
feat: 소스×감성 매트릭스에 기사/댓글 분리 뷰 추가

### DIFF
--- a/apps/web/src/__tests__/explore-aggregations.test.ts
+++ b/apps/web/src/__tests__/explore-aggregations.test.ts
@@ -22,6 +22,7 @@ describe('DEFAULT_FILTERS', () => {
       sentiments: ['positive', 'negative'],
       minScore: 0.7,
       itemType: 'comments',
+      dateScope: 'job',
     };
     expect(valid.sources).toHaveLength(2);
   });

--- a/apps/web/src/components/explore/explore-view.tsx
+++ b/apps/web/src/components/explore/explore-view.tsx
@@ -79,6 +79,16 @@ export function ExploreView({ jobId }: ExploreViewProps) {
     staleTime: Infinity, // 모듈 결과는 분석 완료 후 변경 없음
   });
 
+  const bySourceSplit = useQuery({
+    queryKey: ['explore', jobId, filters.dateScope, 'bySourceSplit'],
+    queryFn: () =>
+      trpcClient.explore.getSentimentBySourceSplit.query({
+        jobId: jobId!,
+        dateScope: filters.dateScope,
+      }),
+    enabled: jobId != null,
+  });
+
   if (!jobId) {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
@@ -96,7 +106,8 @@ export function ExploreView({ jobId }: ExploreViewProps) {
     bySource.isError ||
     scoreDist.isError ||
     scatter.isError ||
-    keywords.isError;
+    keywords.isError ||
+    bySourceSplit.isError;
 
   if (anyError) {
     return (
@@ -112,6 +123,7 @@ export function ExploreView({ jobId }: ExploreViewProps) {
               scoreDist.refetch();
               scatter.refetch();
               keywords.refetch();
+              bySourceSplit.refetch();
             }}
           >
             다시 시도
@@ -138,7 +150,8 @@ export function ExploreView({ jobId }: ExploreViewProps) {
         <ScatterEngagement data={scatter.data} isLoading={scatter.isLoading} />
         <SourceSentimentMatrix
           data={bySource.data}
-          isLoading={bySource.isLoading}
+          splitData={bySourceSplit.data}
+          isLoading={bySource.isLoading || bySourceSplit.isLoading}
           onSelectSource={handleSelectSource}
         />
         <ScoreHistogram data={scoreDist.data} isLoading={scoreDist.isLoading} />

--- a/apps/web/src/components/explore/source-sentiment-matrix.tsx
+++ b/apps/web/src/components/explore/source-sentiment-matrix.tsx
@@ -1,17 +1,27 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { EXPLORE_HELP, SENTIMENT_COLORS } from './explore-help';
 import { CardHelp } from '@/components/dashboard/card-help';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { SOURCE_LABELS } from '@/components/dashboard/collected-data-shared';
+import { cn } from '@/lib/utils';
+
+type SentimentRow = { source: string; sentiment: string; count: number };
+type SplitData = {
+  articles: SentimentRow[];
+  comments: SentimentRow[];
+};
 
 interface SourceSentimentMatrixProps {
-  data: Array<{ source: string; sentiment: string; count: number }> | undefined;
+  data: SentimentRow[] | undefined;
+  splitData: SplitData | undefined;
   isLoading: boolean;
   onSelectSource?: (source: string) => void;
 }
+
+type ViewMode = 'both' | 'articles' | 'comments';
 
 const SENTIMENT_ORDER = ['positive', 'negative', 'neutral'] as const;
 const SENTIMENT_LABEL: Record<string, string> = {
@@ -20,35 +30,63 @@ const SENTIMENT_LABEL: Record<string, string> = {
   neutral: '중립',
 };
 
+function buildRows(rows: SentimentRow[]) {
+  const bySource = new Map<string, { positive: number; negative: number; neutral: number }>();
+  for (const r of rows) {
+    const entry = bySource.get(r.source) ?? { positive: 0, negative: 0, neutral: 0 };
+    if (r.sentiment === 'positive') entry.positive += r.count;
+    else if (r.sentiment === 'negative') entry.negative += r.count;
+    else entry.neutral += r.count;
+    bySource.set(r.source, entry);
+  }
+  return Array.from(bySource.entries())
+    .map(([source, c]) => {
+      const total = c.positive + c.negative + c.neutral;
+      return { source, ...c, total };
+    })
+    .sort((a, b) => b.total - a.total);
+}
+
 export function SourceSentimentMatrix({
   data,
+  splitData,
   isLoading,
   onSelectSource,
 }: SourceSentimentMatrixProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>('both');
+
   const rows = useMemo(() => {
-    if (!data) return [];
-    const bySource = new Map<string, { positive: number; negative: number; neutral: number }>();
-    for (const r of data) {
-      const entry = bySource.get(r.source) ?? { positive: 0, negative: 0, neutral: 0 };
-      if (r.sentiment === 'positive') entry.positive += r.count;
-      else if (r.sentiment === 'negative') entry.negative += r.count;
-      else entry.neutral += r.count;
-      bySource.set(r.source, entry);
-    }
-    return Array.from(bySource.entries())
-      .map(([source, c]) => {
-        const total = c.positive + c.negative + c.neutral;
-        return { source, ...c, total };
-      })
-      .sort((a, b) => b.total - a.total);
-  }, [data]);
+    if (viewMode === 'articles' && splitData) return buildRows(splitData.articles);
+    if (viewMode === 'comments' && splitData) return buildRows(splitData.comments);
+    return buildRows(data ?? []);
+  }, [viewMode, data, splitData]);
 
   return (
     <Card className="min-h-[320px]">
       <CardHeader>
-        <div className="flex items-center gap-2">
-          <CardTitle className="text-base font-semibold">소스 × 감정</CardTitle>
-          <CardHelp {...EXPLORE_HELP.matrix} />
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <CardTitle className="text-base font-semibold">소스 × 감정</CardTitle>
+            <CardHelp {...EXPLORE_HELP.matrix} />
+          </div>
+          <div className="flex items-center gap-1">
+            {(['both', 'articles', 'comments'] as ViewMode[]).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setViewMode(mode)}
+                className={cn(
+                  'px-2 py-1 rounded-md text-xs font-medium transition-colors border',
+                  viewMode === mode
+                    ? 'bg-primary/10 text-primary border-primary/30'
+                    : 'border-border text-muted-foreground hover:text-foreground',
+                )}
+                aria-pressed={viewMode === mode}
+              >
+                {mode === 'both' ? '전체' : mode === 'articles' ? '기사' : '댓글'}
+              </button>
+            ))}
+          </div>
         </div>
       </CardHeader>
       <CardContent>


### PR DESCRIPTION
## Summary

- 탐색 탭의 **소스 × 감성** 카드에 **전체 / 기사 / 댓글** 탭 전환 기능 추가
- 이미 구현되어 있던 `getSentimentBySourceSplit` tRPC 엔드포인트를 UI에서 실제로 활용
- 소스별 감성 분포를 기사와 댓글로 분리하여 비교 가능

## Test plan

- [ ] 탐색 탭 진입 후 "소스 × 감성" 카드 우측 상단에 전체/기사/댓글 탭 버튼 표시 확인
- [ ] 기사 탭 클릭 시 기사 데이터만 표시되는지 확인
- [ ] 댓글 탭 클릭 시 댓글 데이터만 표시되는지 확인
- [ ] 전체 탭이 기본값(합산)으로 동작하는지 확인
- [ ] 기간 필터(수집 기간/전체 기간) 변경 시 분리 뷰도 함께 갱신되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)