### PR TITLE
feat: 수집 run 실시간 진행 상태 UI + heartbeat

### DIFF
--- a/apps/collector/src/db/schema/runs.ts
+++ b/apps/collector/src/db/schema/runs.ts
@@ -21,6 +21,9 @@ export const collectionRuns = pgTable(
     errorReason: text('error_reason'),
     durationMs: integer('duration_ms'),
     triggerType: text('trigger_type', { enum: ['schedule', 'manual'] }).notNull(),
+    // 실시간 진행률 하트비트. executor가 매 청크마다 now()로 갱신.
+    // job.progress(Redis)가 primary이고 이 컬럼은 Redis 장애 시 fallback + UI stalled 판정용.
+    lastProgressAt: timestamp('last_progress_at', { withTimezone: true }),
   },
   (table) => [
     index('collection_runs_subscription_time_idx').on(table.subscriptionId, table.time),

--- a/apps/collector/src/queue/executor.ts
+++ b/apps/collector/src/queue/executor.ts
@@ -225,7 +225,20 @@ export async function executeCollectionJob(
 
       itemsNew += result.length;
 
-      await job.updateProgress({ itemsCollected, itemsNew });
+      // 실시간 진행 상태: Redis(job.progress)에 ts 포함해 저장 + DB(collection_runs)에 하트비트 기록.
+      // UI는 Redis를 primary로 읽고, DB는 Redis 장애 시 fallback 겸 stalled 판정용.
+      const progressTs = Date.now();
+      await job.updateProgress({ itemsCollected, itemsNew, ts: progressTs });
+      await db
+        .update(collectionRuns)
+        .set({ itemsCollected, itemsNew, lastProgressAt: new Date(progressTs) })
+        .where(
+          and(
+            eq(collectionRuns.runId, runId),
+            eq(collectionRuns.source, source),
+            eq(collectionRuns.status, 'running'),
+          ),
+        );
     }
 
     const durationMs = Date.now() - startedAt;
@@ -431,7 +444,19 @@ async function executeCommentsJob(job: Job<CollectionJobData>): Promise<Collecti
             .returning({ insertedAt: rawItems.fetchedAt });
 
           itemsNew += result.length;
-          await job.updateProgress({ itemsCollected, itemsNew });
+          // 댓글 fan-out 경로도 동일 하트비트 — 기사당 1회씩
+          const progressTs = Date.now();
+          await job.updateProgress({ itemsCollected, itemsNew, ts: progressTs });
+          await db
+            .update(collectionRuns)
+            .set({ itemsCollected, itemsNew, lastProgressAt: new Date(progressTs) })
+            .where(
+              and(
+                eq(collectionRuns.runId, runId),
+                eq(collectionRuns.source, source),
+                eq(collectionRuns.status, 'running'),
+              ),
+            );
         }
       } catch (articleErr) {
         // CancelledError는 per-article catch에서 삼키지 않고 outer catch로 전파

--- a/apps/collector/src/server/trpc/runs.ts
+++ b/apps/collector/src/server/trpc/runs.ts
@@ -3,6 +3,8 @@ import { and, desc, eq, gte, inArray, sql } from 'drizzle-orm';
 import { collectionRuns, rawItems, runDiagnostics } from '../../db/schema';
 import { cancelRun, cancelBySubscription, cancelAll, retryRun } from '../../queue/run-control';
 import { collectLayerA } from '../../diagnostics/collect-run';
+import { getCollectQueue } from '../../queue/queues';
+import type { CollectorSource } from '../../queue/types';
 import { protectedProcedure, router } from './init';
 
 const SOURCE_ENUM = [
@@ -134,6 +136,121 @@ export const runsRouter = router({
     .mutation(async ({ input, ctx }) => {
       const triggeredBy = `user:${(ctx.apiKey ?? 'unknown').slice(0, 8)}`;
       return retryRun(input.runId, input.source, triggeredBy);
+    }),
+
+  /**
+   * 실시간 진행 상태. /subscriptions/monitor의 LiveRunFeed + run-actions-modal이 2초 폴링.
+   *
+   * 데이터 소스 우선순위 (liveness 판정):
+   *   1) BullMQ job.progress — {itemsCollected, itemsNew, ts}. Primary.
+   *   2) collection_runs.last_progress_at — Redis 장애 시 fallback
+   *   3) job.processedOn — 워커가 작업을 잡은 시각 (최소 하한)
+   *
+   * byType은 rawItems에서 직접 COUNT — job.progress는 insert 완료 전에 찍히므로
+   * "DB에 실제 적재된 수"를 UI가 교차 검증할 수 있게 한다.
+   */
+  progress: protectedProcedure
+    .input(
+      z.object({
+        runId: z.string().uuid(),
+        source: z.enum(SOURCE_ENUM),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      const { runId, source } = input;
+      const jobId = `${runId}-${source}`;
+
+      // 1) BullMQ job — state/progress/timestamps
+      let bullState: string = 'unknown';
+      let attemptsMade = 0;
+      let failedReason: string | null = null;
+      let jobProgress: { itemsCollected?: number; itemsNew?: number; ts?: number } = {};
+      let processedOnMs: number | null = null;
+      let finishedOnMs: number | null = null;
+      let timestampMs: number | null = null;
+      try {
+        const queue = getCollectQueue(source as CollectorSource);
+        const job = await queue.getJob(jobId);
+        if (job) {
+          bullState = await job.getState();
+          attemptsMade = job.attemptsMade ?? 0;
+          failedReason = job.failedReason ?? null;
+          const raw = job.progress;
+          if (raw && typeof raw === 'object') {
+            jobProgress = raw as typeof jobProgress;
+          }
+          processedOnMs = job.processedOn ?? null;
+          finishedOnMs = job.finishedOn ?? null;
+          timestampMs = job.timestamp ?? null;
+        }
+      } catch (err) {
+        // Redis 장애는 degradation — DB fallback으로 계속
+        console.warn(
+          `[runs.progress] BullMQ 조회 실패 runId=${runId} source=${source}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        bullState = 'unreachable';
+      }
+
+      // 2) DB — 최신 collection_runs row + rawItems byType 집계 병렬
+      const [runRowResult, byTypeRows] = await Promise.all([
+        ctx.db
+          .select()
+          .from(collectionRuns)
+          .where(and(eq(collectionRuns.runId, runId), eq(collectionRuns.source, source)))
+          .orderBy(desc(collectionRuns.time))
+          .limit(1),
+        ctx.db
+          .select({
+            itemType: rawItems.itemType,
+            count: sql<number>`count(*)::int`,
+          })
+          .from(rawItems)
+          .where(eq(rawItems.fetchedFromRun, runId))
+          .groupBy(rawItems.itemType),
+      ]);
+      const [runRow] = runRowResult;
+
+      const byType = { article: 0, video: 0, comment: 0 };
+      for (const r of byTypeRows) {
+        byType[r.itemType as keyof typeof byType] = r.count;
+      }
+
+      // liveness 결정: Redis progress ts → DB last_progress_at → job.processedOn
+      const dbLastProgressMs = runRow?.lastProgressAt ? runRow.lastProgressAt.getTime() : null;
+      const lastProgressAtMs =
+        jobProgress.ts && dbLastProgressMs
+          ? Math.max(jobProgress.ts, dbLastProgressMs)
+          : (jobProgress.ts ?? dbLastProgressMs ?? processedOnMs);
+
+      // itemsCollected/itemsNew도 Redis 우선, 없으면 DB
+      const itemsCollected = jobProgress.itemsCollected ?? runRow?.itemsCollected ?? 0;
+      const itemsNew = jobProgress.itemsNew ?? runRow?.itemsNew ?? 0;
+
+      const startedAtMs = runRow?.time?.getTime() ?? timestampMs ?? null;
+      const elapsedMs =
+        finishedOnMs && startedAtMs
+          ? finishedOnMs - startedAtMs
+          : startedAtMs
+            ? Date.now() - startedAtMs
+            : 0;
+
+      return {
+        runId,
+        source,
+        status: runRow?.status ?? null,
+        bullState,
+        attemptsMade,
+        itemsCollected,
+        itemsNew,
+        byType,
+        lastProgressAtMs,
+        processedOnMs,
+        finishedOnMs,
+        elapsedMs,
+        failedReason,
+      };
     }),
 
   diagnose: protectedProcedure

--- a/apps/web/src/components/subscriptions/live-run-feed.tsx
+++ b/apps/web/src/components/subscriptions/live-run-feed.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from 'lucide-react';
 import { SOURCE_LABEL_MAP } from './subscription-utils';
 import { CopyableClaudeRef } from './copyable-claude-ref';
 import { RunRowActions } from './run-row-actions';
+import { RunProgressInline } from './run-progress-inline';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { RunRecord } from '@/server/trpc/routers/subscriptions';
@@ -88,7 +89,12 @@ export function LiveRunFeed({ runs, subscriptionMap }: LiveRunFeedProps) {
                 {keyword && <span className="font-medium truncate max-w-[160px]">{keyword}</span>}
                 <span className="text-muted-foreground">→</span>
                 <span className="text-xs">{SOURCE_LABEL_MAP[run.source] ?? run.source}</span>
-                <div className="ml-auto flex items-center gap-2">
+                <div className="ml-auto flex items-center gap-3 flex-wrap justify-end">
+                  <RunProgressInline
+                    runId={run.runId}
+                    source={run.source}
+                    active={run.status === 'running'}
+                  />
                   <span className="text-xs text-muted-foreground tabular-nums">
                     <ElapsedTimer since={new Date(run.time)} />
                   </span>

--- a/apps/web/src/components/subscriptions/run-actions-modal.tsx
+++ b/apps/web/src/components/subscriptions/run-actions-modal.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { AlertTriangle, Loader2 } from 'lucide-react';
+import { RunProgressInline } from './run-progress-inline';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
@@ -94,6 +95,14 @@ export function RunActionsModal() {
           </TabsList>
 
           <TabsContent value="diagnose" className="space-y-3 mt-4">
+            {source && (
+              <RunProgressInline
+                runId={runId}
+                source={source}
+                active={isRunActive(diagQuery.data as DiagData | null | undefined)}
+                variant="full"
+              />
+            )}
             {diagQuery.isLoading && (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" /> 불러오는 중...
@@ -167,6 +176,16 @@ type DiagData = {
   layerB: LayerB | null;
   layerC: LayerC | null;
 };
+
+/**
+ * 진단 payload에서 현재 run이 "실시간 폴링 대상"인지 판단.
+ * layerA가 아직 없으면 (최초 로드) 보수적으로 active 간주해 progress 스피너를 띄움.
+ */
+function isRunActive(data: DiagData | null | undefined): boolean {
+  if (!data) return true;
+  const state = data.layerA?.bullState;
+  return state === 'active' || state === 'waiting' || state === 'delayed';
+}
 
 type LayerA = {
   bullState: string;

--- a/apps/web/src/components/subscriptions/run-progress-inline.tsx
+++ b/apps/web/src/components/subscriptions/run-progress-inline.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { trpcClient } from '@/lib/trpc';
+import type { RunProgress } from '@/server/trpc/routers/subscriptions';
+
+// web proxy에 등록된 소스 enum과 맞춤. naver-comments는 독립 run UI에서 쓰지 않음.
+type ProxySource = 'naver-news' | 'youtube' | 'dcinside' | 'fmkorea' | 'clien';
+const PROXY_SOURCES: ProxySource[] = ['naver-news', 'youtube', 'dcinside', 'fmkorea', 'clien'];
+
+const POLL_MS = 2000;
+const STALE_MS = 1000;
+
+interface RunProgressInlineProps {
+  runId: string;
+  source: string;
+  /** 'running'일 때만 폴링 활성. 다른 상태면 refetch 중단으로 네트워크 절약. */
+  active: boolean;
+  /** 'compact' (LiveRunFeed row) | 'full' (modal 상단) */
+  variant?: 'compact' | 'full';
+}
+
+/**
+ * 현재 실행 중인 수집 run의 실시간 진행 상태를 표시한다.
+ *
+ * - 2초 폴링 (TanStack Query). 동일 (runId, source)은 queryKey 공유로 중복 요청 제거
+ * - lastProgressAtMs → Date.now()로 heartbeat age 계산. 1초 간격 client setInterval
+ * - 30s+ 무응답이면 "응답 없음" 경고. 실제 stalled 판정은 서버(StalledRunsBanner)가 담당
+ */
+export function RunProgressInline({
+  runId,
+  source,
+  active,
+  variant = 'compact',
+}: RunProgressInlineProps) {
+  // naver-comments 등 proxy enum에 없는 소스는 폴링 대상에서 제외 (서버에서 enum 검증 실패로 500 방지).
+  const isPollable = (PROXY_SOURCES as readonly string[]).includes(source);
+  const query = useQuery({
+    queryKey: ['run-progress', runId, source],
+    queryFn: () =>
+      trpcClient.subscriptions.runProgress.query({
+        runId,
+        source: source as ProxySource,
+      }),
+    enabled: isPollable,
+    refetchInterval: active && isPollable ? POLL_MS : false,
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: false,
+  });
+
+  // 서버에서 받은 lastProgressAtMs가 바뀌어도 UI age는 클라 틱으로 계속 증가해야
+  // "2초마다 갱신되는 숫자"가 끊기지 않는다.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [active]);
+
+  const data = query.data as RunProgress | undefined;
+  if (!data) {
+    // 첫 로드 전엔 조용히 skeleton. row 레이아웃 안 깨지게 고정폭 사용
+    return variant === 'compact' ? (
+      <span className="text-xs text-muted-foreground tabular-nums opacity-60">수집…</span>
+    ) : null;
+  }
+
+  const { byType, itemsNew, lastProgressAtMs } = data;
+  const ageMs = lastProgressAtMs ? now - lastProgressAtMs : null;
+  const heartbeat = classifyHeartbeat(ageMs, active);
+
+  const summary = buildSummary(byType, itemsNew, source);
+
+  if (variant === 'full') {
+    return (
+      <div className="flex items-center gap-3 rounded-md border bg-muted/30 px-3 py-2 text-sm">
+        <HeartbeatDot kind={heartbeat.kind} />
+        <div className="flex-1 min-w-0">
+          <div className="font-medium tabular-nums">{summary}</div>
+          <div className={`text-xs ${heartbeat.textClass}`}>{heartbeat.label}</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs tabular-nums">
+      <HeartbeatDot kind={heartbeat.kind} />
+      <span className="text-foreground/90">{summary}</span>
+      <span className={`${heartbeat.textClass}`}>· {heartbeat.label}</span>
+    </span>
+  );
+}
+
+/** article + comment 중심. video는 YouTube 구독에서만 의미. */
+function buildSummary(
+  byType: { article: number; video: number; comment: number },
+  itemsNew: number,
+  source: string,
+): string {
+  if (source === 'youtube') {
+    return `영상 ${byType.video} · 댓글 ${byType.comment} · 신규 ${itemsNew}`;
+  }
+  if (source === 'naver-comments') {
+    return `댓글 ${byType.comment} · 신규 ${itemsNew}`;
+  }
+  return `기사 ${byType.article} · 댓글 ${byType.comment} · 신규 ${itemsNew}`;
+}
+
+type HeartbeatKind = 'live' | 'idle' | 'slow' | 'stalled' | 'inactive';
+
+function classifyHeartbeat(
+  ageMs: number | null,
+  active: boolean,
+): { kind: HeartbeatKind; label: string; textClass: string } {
+  if (!active) {
+    return { kind: 'inactive', label: '종료됨', textClass: 'text-muted-foreground' };
+  }
+  if (ageMs == null) {
+    return { kind: 'idle', label: '대기 중', textClass: 'text-muted-foreground' };
+  }
+  const sec = Math.floor(ageMs / 1000);
+  if (sec < 10) {
+    return { kind: 'live', label: '방금 전', textClass: 'text-muted-foreground' };
+  }
+  if (sec < 30) {
+    return { kind: 'idle', label: `${sec}초 전`, textClass: 'text-muted-foreground' };
+  }
+  if (sec < 60) {
+    return { kind: 'slow', label: `응답 없음 ${sec}s`, textClass: 'text-yellow-600' };
+  }
+  const min = Math.floor(sec / 60);
+  return { kind: 'stalled', label: `응답 없음 ${min}분`, textClass: 'text-red-600' };
+}
+
+function HeartbeatDot({ kind }: { kind: HeartbeatKind }) {
+  if (kind === 'live') {
+    return (
+      <span className="relative inline-flex h-2 w-2 shrink-0" aria-label="수집 진행 중">
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+        <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
+      </span>
+    );
+  }
+  const color =
+    kind === 'slow'
+      ? 'bg-yellow-500'
+      : kind === 'stalled'
+        ? 'bg-red-500'
+        : kind === 'inactive'
+          ? 'bg-muted-foreground/40'
+          : 'bg-muted-foreground/60';
+  return <span className={`inline-flex h-2 w-2 shrink-0 rounded-full ${color}`} aria-hidden />;
+}

--- a/apps/web/src/server/trpc/routers/subscriptions.ts
+++ b/apps/web/src/server/trpc/routers/subscriptions.ts
@@ -89,6 +89,22 @@ export interface RunItemBreakdownEntry {
   count: number;
 }
 
+export interface RunProgress {
+  runId: string;
+  source: string;
+  status: 'running' | 'completed' | 'blocked' | 'failed' | null;
+  bullState: string;
+  attemptsMade: number;
+  itemsCollected: number;
+  itemsNew: number;
+  byType: { article: number; video: number; comment: number };
+  lastProgressAtMs: number | null;
+  processedOnMs: number | null;
+  finishedOnMs: number | null;
+  elapsedMs: number;
+  failedReason: string | null;
+}
+
 export interface CancelResult {
   runId: string;
   source: string;
@@ -429,6 +445,22 @@ export const subscriptionsRouter = router({
       try {
         const res = await getCollectorClient().runs.itemBreakdown.query(input);
         return res as unknown as RunItemBreakdownEntry[];
+      } catch (err) {
+        handleCollectorError(err);
+      }
+    }),
+
+  runProgress: protectedProcedure
+    .input(
+      z.object({
+        runId: z.string().uuid(),
+        source: z.enum(SOURCE_ENUM),
+      }),
+    )
+    .query(async ({ input }): Promise<RunProgress> => {
+      try {
+        const res = await getCollectorClient().runs.progress.query(input);
+        return res as unknown as RunProgress;
       } catch (err) {
         handleCollectorError(err);
       }


### PR DESCRIPTION
## Summary
- 수집 run 진행 중인데 UI가 "실행 중"만 표시해 멈춘 것으로 착각하던 문제 해결
- LiveRunFeed row / RunActionsModal 진단 탭에 `기사 N · 댓글 M · 신규 K` 카운터 + 하트비트 dot 노출
- Redis primary (job.progress) + DB fallback (collection_runs.last_progress_at) 이중 기록으로 Redis 장애에도 degradation

## 변경 내역

### Collector
- `collection_runs.last_progress_at` 컬럼 추가 (하이퍼테이블, Drizzle push)
- `executor.ts`: 매 청크마다 `job.updateProgress({itemsCollected, itemsNew, ts})` + DB partial UPDATE 병렬 기록 (naver-comments fan-out 경로도 동일)
- `runs.progress` tRPC procedure 신규 — BullMQ state/progress + DB row + raw_items byType 집계 일괄 반환

### Web
- `subscriptions.runProgress` proxy
- `RunProgressInline` 컴포넌트 (compact/full variant): count-up 텍스트 + heartbeat dot (<10s 녹색 pulsing / <30s 회색 / <60s 노랑 / ≥60s 빨강)
- LiveRunFeed row 내부 compact, RunActionsModal 진단 탭 상단 full — queryKey 공유로 네트워크 요청 1개

## Test plan
- [ ] `pnpm --filter @ai-signalcraft/collector db:push` 로 컬럼 반영 (로컬 완료)
- [ ] 운영 배포 후 dcinside 수동 트리거 → LiveRunFeed row에서 2초 주기로 기사/댓글 카운트 증가
- [ ] 같은 run을 modal 진단 탭에서 열어 full variant 동일 카운터 확인, Network 탭에 `runs.progress` 요청 1개만
- [ ] collector-worker를 임의 중지 후 30초 대기 → "응답 없음" 노랑 배지 표시, 워커 복구 시 자동 해제
- [ ] run 종료(completed/failed) 시 refetchInterval=false 로 폴링 정지
- [ ] `raw_items WHERE fetched_from_run GROUP BY item_type` vs UI 카운터 ≤10 차이

## 후속 작업 (별도 PR)
- SSE 전환 (tRPC v11 `httpSubscriptionLink` 스파이크)
- 어댑터 메타 구조화 (현재 페이지/마지막 publishedAt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)