### PR TITLE
수집 단계 증분 댓글 수집 + 개별 감정 이동

### DIFF
--- a/docs/technical/plans/2026-04-21-수집단계-증분감정-plan.md
+++ b/docs/technical/plans/2026-04-21-수집단계-증분감정-plan.md
@@ -1,0 +1,1724 @@
+# 수집 단계 통합 (증분 댓글 수집 + 개별 감정 수집 단계 이동) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 수집 완료 시 댓글을 증분으로만 받고 개별 감정 분류까지 마쳐서, 분석 트리거 시점에는 sentiment가 항상 채워진 상태가 되게 한다.
+
+**Architecture:** persist 완료 후 새 `classify` 파이프라인 노드(pipeline 큐 재사용)가 증분 `analyzeItems`를 돌린 뒤 `triggerAnalysis`를 호출한다. `comments.first_seen_at` 컬럼으로 최초 등장 시점을 보존하고, 네이버/유튜브 댓글 어댑터는 `since` 인자로 조기 종료한다. 커뮤니티는 어댑터 변경 없이 스키마 정책만으로 달성(YAGNI).
+
+**Tech Stack:** pnpm · Drizzle ORM · BullMQ FlowProducer · PostgreSQL 16 · `@xenova/transformers` (ONNX BERT) · Vitest 3 · TypeScript 5
+
+**Spec:** `docs/technical/specs/2026-04-21-수집단계-증분감정-design.md`
+
+---
+
+## File Structure
+
+### 생성
+
+- `packages/core/src/analysis/__tests__/item-analyzer.incremental.test.ts`
+- `packages/core/src/pipeline/__tests__/reuse-planner.refetch-spec.test.ts`
+- `packages/collectors/src/adapters/__tests__/naver-comments.incremental.test.ts`
+- `packages/collectors/src/adapters/__tests__/youtube-comments.incremental.test.ts`
+- `packages/core/src/queue/__tests__/triggerClassify.test.ts`
+
+### 수정
+
+- `packages/core/src/db/schema/collections.ts` — `comments.firstSeenAt` 컬럼 추가
+- `packages/core/src/pipeline/persist.ts` — `onConflictDoUpdate.set`에서 `firstSeenAt` 제외 확인 (코드 변경 없음, 주석 확인만)
+- `packages/core/src/pipeline/reuse-planner.ts` — `RefetchCommentSpec` 타입 신설, `ArticleReusePlan.refetchCommentsFor` / `VideoReusePlan.refetchCommentsFor` 타입 변경
+- `packages/core/src/queue/flows.ts` — `triggerClassify()` 추가, `ReusePlanPayload`의 `refetchCommentsFor` 타입 동반 변경
+- `packages/core/src/types/index.ts` 또는 `packages/core/src/types/pipeline.ts` (둘 중 `ReusePlanPayload` 정의 위치) — 타입 변경
+- `packages/collectors/src/adapters/naver-comments.ts` — `collectForArticle` 시그니처 확장, since 모드에서 `sort='NEW'` + 연속 20개 컷오프
+- `packages/collectors/src/adapters/youtube-comments.ts` — `since` 옵션 추가 (CollectionOptions 또는 별도 파라미터), `order='time'` 사용 + publishedAt 컷오프
+- `packages/collectors/src/adapters/base.ts` — `CollectionOptions`에 `since?: string` 추가 (ISO 문자열)
+- `packages/core/src/queue/pipeline-worker.ts` — `classify` 분기 추가, `persist`에서 `triggerAnalysis` → `triggerClassify` 교체, 네이버 댓글 수집부에 `since` 전달, YouTube collect-worker 경로에 `since` 전달
+- `packages/core/src/analysis/item-analyzer.ts` — `isNull(sentiment)` 필터, `articlesSkipped`/`commentsSkipped` 카운트
+
+### 각 파일 책임
+
+- `item-analyzer.ts` — 증분 감정 분류 진입점. "어떤 row를 분류할지"의 단일 진실.
+- `flows.ts` — 큐 노드 트리거 함수만. 노드 데이터 직렬화 정책 담당.
+- `pipeline-worker.ts` — BullMQ job handler 분기. `normalize` / `persist` / `classify` 각 분기가 독립 가능하도록 유지.
+- `reuse-planner.ts` — TTL 재사용 판정. 신규 타입 `RefetchCommentSpec` 정의 소유.
+- `naver-comments.ts` / `youtube-comments.ts` — 각 소스의 댓글 어댑터. since 인자 해석은 여기서만.
+- `collections.ts` (schema) — `first_seen_at` 단일 출처.
+
+---
+
+## Task 1: comments.first_seen_at 컬럼 추가
+
+**Files:**
+
+- Modify: `packages/core/src/db/schema/collections.ts:174-200`
+
+- [ ] **Step 1: 스키마 파일 확인**
+
+Run: `rg -n "export const comments = pgTable" packages/core/src/db/schema/collections.ts`
+Expected: line 175 근처 매치.
+
+- [ ] **Step 2: `firstSeenAt` 컬럼 추가**
+
+`packages/core/src/db/schema/collections.ts`의 comments 테이블에서, `collectedAt` 선언 바로 뒤에 추가:
+
+```typescript
+firstSeenAt: timestamp('first_seen_at').defaultNow().notNull(),
+```
+
+전체 comments 테이블은 다음과 같은 형태가 된다 (변경 부분 컨텍스트):
+
+```typescript
+export const comments = pgTable(
+  'comments',
+  {
+    // ... 기존 컬럼들 유지 ...
+    rawData: jsonb('raw_data'),
+    embedding: vector384('embedding'),
+    collectedAt: timestamp('collected_at').defaultNow().notNull(),
+    firstSeenAt: timestamp('first_seen_at').defaultNow().notNull(),
+  },
+  (table) => [uniqueIndex('comments_source_id_idx').on(table.source, table.sourceId)],
+);
+```
+
+- [ ] **Step 3: 타입 체크**
+
+Run: `pnpm --filter @ai-signalcraft/core typecheck` (없으면 `pnpm -w -r typecheck` 또는 `pnpm build`)
+Expected: 에러 없음 — 타입이 자동으로 `$inferInsert`/`$inferSelect`에 반영됨.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add packages/core/src/db/schema/collections.ts
+git commit -m "feat(db): comments 테이블에 first_seen_at 컬럼 추가
+
+댓글 최초 등장 시점 영구 보존용. persistComments의 onConflictDoUpdate에서
+제외되어 upsert 시에도 보존된다.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: persistComments가 first_seen_at을 덮어쓰지 않는지 검증
+
+**Files:**
+
+- Verify: `packages/core/src/pipeline/persist.ts:152-176`
+
+- [ ] **Step 1: 현재 onConflictDoUpdate.set 확인**
+
+Run: `rg -n "onConflictDoUpdate" packages/core/src/pipeline/persist.ts`
+Expected: `persistComments` 안의 set 절 3개(content/likeCount/dislikeCount/rawData/collectedAt)에 `firstSeenAt`이 없는지 확인.
+
+- [ ] **Step 2: 주석으로 정책 명시**
+
+`packages/core/src/pipeline/persist.ts`의 `persistComments` 내 `onConflictDoUpdate` 위에 한 줄 주석 추가:
+
+```typescript
+// first_seen_at은 onConflictDoUpdate.set에서 의도적으로 제외 — 최초 등장 시점 보존
+.onConflictDoUpdate({
+  target: [comments.source, comments.sourceId],
+  set: {
+    content: sql`excluded.content`,
+    // ... 기존 set 유지 ...
+  },
+})
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add packages/core/src/pipeline/persist.ts
+git commit -m "docs(persist): first_seen_at 보존 정책 주석 명시
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: 운영/개발 DB에 컬럼 반영 (db:push)
+
+**Files:** (스키마만, 마이그레이션 파일 없음 — Drizzle push 방식)
+
+- [ ] **Step 1: 개발 DB push 시뮬레이션**
+
+Run: `pnpm db:push --dry-run` (지원 시) 또는 `pnpm db:push` 후 즉시 `rg "first_seen_at" drizzle/` (meta 스냅샷 확인)
+
+Expected: `ALTER TABLE "comments" ADD COLUMN "first_seen_at" timestamp DEFAULT now() NOT NULL` 같은 SQL 포함.
+
+- [ ] **Step 2: 개발 DB에 실제 적용**
+
+Run: `pnpm db:push`
+Expected: 에러 없음, "completed" 또는 "no changes" 이후 확인 가능.
+
+- [ ] **Step 3: psql로 검증**
+
+Run (개발 환경 DB에 접근 가능한 셸에서):
+
+```bash
+psql postgresql://<dev-dsn> -c "\d comments" | grep first_seen_at
+```
+
+Expected: `first_seen_at | timestamp without time zone | not null | now()` 같은 행이 출력됨.
+
+> **주의**: 운영 DB 반영은 **Task 14 배포 단계**에서 진행. 이 단계에서는 개발 DB만.
+
+- [ ] **Step 4: 커밋 없음** (스키마 파일은 이미 Task 1에서 커밋됨)
+
+---
+
+## Task 4: CollectionOptions에 since 필드 추가
+
+**Files:**
+
+- Modify: `packages/collectors/src/adapters/base.ts:3-32`
+
+- [ ] **Step 1: Zod 스키마에 since 추가**
+
+`packages/collectors/src/adapters/base.ts`의 `CollectionOptionsSchema`에 `commentOrder` 바로 위 라인에 추가:
+
+```typescript
+// 증분 댓글 수집 컷오프. 이 시각 이후(publishedAt > since)의 댓글만 수집.
+// 네이버/유튜브 댓글 어댑터만 해석한다 (커뮤니티 어댑터는 무시).
+since: z.string().datetime().optional(),
+```
+
+최종 스키마 (`commentOrder` 부근):
+
+```typescript
+// ... 기존 필드들 ...
+since: z.string().datetime().optional(),
+commentOrder: z.enum(['relevance', 'time']).default('relevance').optional(),
+collectTranscript: z.boolean().default(true).optional(),
+});
+```
+
+- [ ] **Step 2: 타입 체크**
+
+Run: `pnpm --filter @ai-signalcraft/collectors build` 또는 최상위 `pnpm -w build`
+Expected: 에러 없음.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add packages/collectors/src/adapters/base.ts
+git commit -m "feat(collectors): CollectionOptions에 since 옵션 추가
+
+네이버/유튜브 댓글 어댑터의 증분 수집 컷오프용 ISO 문자열 타임스탬프.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: NaverCommentsCollector — 증분 수집 테스트 작성
+
+**Files:**
+
+- Create: `packages/collectors/src/adapters/__tests__/naver-comments.incremental.test.ts`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+```typescript
+// packages/collectors/src/adapters/__tests__/naver-comments.incremental.test.ts
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { NaverCommentsCollector } from '../naver-comments';
+
+// fetch를 모킹해 네이버 댓글 API 응답 흉내
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonpReply(
+  comments: Array<{ commentNo: string; regTime: string; contents: string }>,
+  totalPages = 1,
+) {
+  const payload = {
+    result: {
+      commentList: comments.map((c) => ({
+        commentNo: c.commentNo,
+        regTime: c.regTime,
+        modTime: c.regTime,
+        contents: c.contents,
+        sympathyCount: 0,
+        antipathyCount: 0,
+        maskedUserId: 'x',
+      })),
+      pageModel: { totalPages },
+    },
+  };
+  const body = `_callback(${JSON.stringify(payload)});`;
+  return { ok: true, status: 200, text: async () => body } as Response;
+}
+
+describe('NaverCommentsCollector 증분 수집', () => {
+  it('since 이후의 댓글만 반환한다', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonpReply([
+        { commentNo: '3', regTime: '2026-04-21T10:00:00Z', contents: 'new' },
+        { commentNo: '2', regTime: '2026-04-20T10:00:00Z', contents: 'old1' },
+        { commentNo: '1', regTime: '2026-04-19T10:00:00Z', contents: 'old2' },
+      ]),
+    );
+
+    const collector = new NaverCommentsCollector();
+    const url = 'https://n.news.naver.com/article/001/0000000001';
+    const since = new Date('2026-04-20T12:00:00Z');
+
+    const collected: string[] = [];
+    for await (const chunk of collector.collectForArticle(url, { maxComments: 100, since })) {
+      for (const c of chunk) collected.push(c.sourceId);
+    }
+
+    expect(collected).toEqual(['3']);
+  });
+
+  it('since 이전 댓글이 연속 20개 나오면 조기 종료한다', async () => {
+    // 페이지 1: 최신 5개는 since 이후, 나머지 20개는 since 이전
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      commentNo: String(1000 - i),
+      regTime:
+        i < 5
+          ? `2026-04-21T${String(10 - i).padStart(2, '0')}:00:00Z`
+          : `2026-04-19T${String(10 - (i % 10)).padStart(2, '0')}:00:00Z`,
+      contents: `c${i}`,
+    }));
+    mockFetch.mockResolvedValueOnce(jsonpReply(page1, 5));
+
+    const collector = new NaverCommentsCollector();
+    const url = 'https://n.news.naver.com/article/001/0000000001';
+    const since = new Date('2026-04-20T12:00:00Z');
+
+    const collected: string[] = [];
+    for await (const chunk of collector.collectForArticle(url, { maxComments: 500, since })) {
+      for (const c of chunk) collected.push(c.sourceId);
+    }
+
+    // 연속 20개 cutoff → 페이지 2 이후 fetch 호출 없음
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(collected.length).toBe(5);
+  });
+
+  it('since 미지정 시 기존 동작(전량 수집, FAVORITE 정렬)을 유지한다', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonpReply(
+        [
+          { commentNo: '2', regTime: '2026-04-19T10:00:00Z', contents: 'a' },
+          { commentNo: '1', regTime: '2026-04-18T10:00:00Z', contents: 'b' },
+        ],
+        1,
+      ),
+    );
+
+    const collector = new NaverCommentsCollector();
+    const url = 'https://n.news.naver.com/article/001/0000000001';
+    const collected: string[] = [];
+    for await (const chunk of collector.collectForArticle(url, { maxComments: 100 })) {
+      for (const c of chunk) collected.push(c.sourceId);
+    }
+    expect(collected).toEqual(['2', '1']);
+    // 첫 호출 URL에 sort=FAVORITE 포함
+    const firstCallUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstCallUrl).toMatch(/sort=FAVORITE/);
+  });
+
+  it('since 지정 시 호출 URL에 sort=NEW가 포함된다', async () => {
+    mockFetch.mockResolvedValueOnce(jsonpReply([], 0));
+    const collector = new NaverCommentsCollector();
+    const url = 'https://n.news.naver.com/article/001/0000000001';
+    for await (const _ of collector.collectForArticle(url, {
+      maxComments: 10,
+      since: new Date('2026-04-20T00:00:00Z'),
+    })) {
+      // drain
+    }
+    const firstCallUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstCallUrl).toMatch(/sort=NEW/);
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors test -- naver-comments.incremental`
+Expected: 4건 모두 FAIL — `since` 파라미터 미구현 및 시그니처 mismatch.
+
+---
+
+## Task 6: NaverCommentsCollector — since 지원 구현
+
+**Files:**
+
+- Modify: `packages/collectors/src/adapters/naver-comments.ts:80-168`
+
+- [ ] **Step 1: `collectForArticle` 시그니처 및 구현 확장**
+
+전체 `collectForArticle` 메서드를 아래로 교체:
+
+```typescript
+async *collectForArticle(
+  articleUrl: string,
+  options?: { maxComments?: number; since?: Date; sort?: 'FAVORITE' | 'NEW' },
+): AsyncGenerator<NaverComment[], void, unknown> {
+  const parsed = parseNaverArticleUrl(articleUrl);
+  if (!parsed) {
+    throw new Error(`네이버 뉴스 URL을 파싱할 수 없습니다: ${articleUrl}`);
+  }
+
+  const { oid, aid } = parsed;
+  const objectId = buildObjectId(oid, aid);
+  const articleSourceId = `${oid}_${aid}`;
+  const maxComments = options?.maxComments ?? DEFAULT_MAX_COMMENTS;
+  const since = options?.since ?? null;
+  // since가 있으면 기본 NEW (최신순), 없으면 기존 FAVORITE (인기순) 유지
+  const sort = options?.sort ?? (since ? 'NEW' : 'FAVORITE');
+  const OLD_CONSECUTIVE_CUTOFF = 20;
+
+  let totalCollected = 0;
+  let currentPage = 1;
+  let consecutiveOld = 0;
+
+  const referer = `https://n.news.naver.com/article/comment/${oid}/${aid}`;
+
+  pageLoop: while (totalCollected < maxComments) {
+    const apiUrl = buildCommentApiUrl({
+      objectId,
+      page: currentPage,
+      pageSize: 100,
+      sort,
+    });
+
+    const response = await fetch(apiUrl, {
+      headers: {
+        ...BASE_HEADERS,
+        Referer: referer,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`댓글 API 요청 실패: ${response.status} ${response.statusText}`);
+    }
+
+    const text = await response.text();
+    let data: Record<string, unknown>;
+    try {
+      data = parseJsonpResponse(text) as Record<string, unknown>;
+    } catch {
+      throw new Error(`댓글 API 응답 파싱 실패 (page ${currentPage})`);
+    }
+
+    const result = data.result as Record<string, unknown> | undefined;
+    if (!result) break;
+    const commentList = result.commentList as Array<Record<string, unknown>> | undefined;
+    if (!commentList || commentList.length === 0) break;
+
+    const comments: NaverComment[] = [];
+    for (const raw of commentList) {
+      if (totalCollected >= maxComments) break pageLoop;
+
+      const publishedAt: Date | null = raw.modTime
+        ? new Date(String(raw.modTime))
+        : raw.regTime
+          ? new Date(String(raw.regTime))
+          : null;
+
+      // since cutoff: publishedAt <= since 이면 "오래된 것"으로 카운트
+      if (since && publishedAt && publishedAt.getTime() <= since.getTime()) {
+        consecutiveOld++;
+        if (consecutiveOld >= OLD_CONSECUTIVE_CUTOFF) break pageLoop;
+        continue;
+      }
+      consecutiveOld = 0;
+
+      comments.push({
+        sourceId: String(raw.commentNo ?? raw.ticket ?? ''),
+        parentId: raw.parentCommentNo ? String(raw.parentCommentNo) : null,
+        articleSourceId,
+        content: String(raw.contents ?? ''),
+        author: String(raw.maskedUserId ?? raw.userName ?? '익명'),
+        likeCount: Number(raw.sympathyCount ?? 0),
+        dislikeCount: Number(raw.antipathyCount ?? 0),
+        publishedAt,
+        rawData: raw,
+      });
+      totalCollected++;
+    }
+
+    if (comments.length > 0) yield comments;
+
+    const pageModel = result.pageModel as Record<string, unknown> | undefined;
+    const totalPages = Number(pageModel?.totalPages ?? 1);
+    if (currentPage >= totalPages) break;
+
+    currentPage++;
+    await delay(REQUEST_DELAY_MS, REQUEST_DELAY_MS + 500);
+  }
+}
+```
+
+- [ ] **Step 2: 테스트 통과 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors test -- naver-comments.incremental`
+Expected: 4건 PASS.
+
+- [ ] **Step 3: 기존 네이버 관련 테스트 회귀 없음 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors test -- naver`
+Expected: 전부 PASS.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add packages/collectors/src/adapters/naver-comments.ts \
+        packages/collectors/src/adapters/__tests__/naver-comments.incremental.test.ts
+git commit -m "feat(collectors): 네이버 댓글 어댑터 증분 수집 지원
+
+- collectForArticle에 since/sort 옵션 추가
+- since 지정 시 sort=NEW로 전환, publishedAt<=since 연속 20개면 조기 종료
+- since 미지정 시 기존 FAVORITE 동작 유지
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: YoutubeCommentsCollector — 증분 수집 테스트 작성
+
+**Files:**
+
+- Create: `packages/collectors/src/adapters/__tests__/youtube-comments.incremental.test.ts`
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+```typescript
+// packages/collectors/src/adapters/__tests__/youtube-comments.incremental.test.ts
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { YoutubeCommentsCollector } from '../youtube-comments';
+
+const listMock = vi.fn();
+vi.mock('../../utils/youtube-client', () => ({
+  getYoutubeClient: () => ({
+    commentThreads: { list: listMock },
+  }),
+}));
+
+function mkThread(id: string, publishedAt: string) {
+  return {
+    snippet: {
+      topLevelComment: {
+        id,
+        snippet: {
+          textDisplay: `c${id}`,
+          authorDisplayName: 'u',
+          likeCount: 0,
+          publishedAt,
+        },
+      },
+    },
+    replies: null,
+  };
+}
+
+beforeEach(() => {
+  listMock.mockReset();
+});
+
+describe('YoutubeCommentsCollector 증분 수집', () => {
+  it('since 이후의 댓글만 반환한다', async () => {
+    listMock.mockResolvedValueOnce({
+      data: {
+        items: [
+          mkThread('3', '2026-04-21T10:00:00Z'),
+          mkThread('2', '2026-04-20T10:00:00Z'),
+          mkThread('1', '2026-04-19T10:00:00Z'),
+        ],
+        nextPageToken: undefined,
+      },
+    });
+
+    const collector = new YoutubeCommentsCollector();
+    const collected: string[] = [];
+    for await (const chunk of collector.collect({
+      keyword: 'video-xyz',
+      startDate: '2026-04-01T00:00:00Z',
+      endDate: '2026-04-30T00:00:00Z',
+      maxComments: 100,
+      since: '2026-04-20T12:00:00Z',
+      commentOrder: 'time',
+    })) {
+      for (const c of chunk) collected.push(c.sourceId);
+    }
+
+    expect(collected).toEqual(['3']);
+    // since 지정 시 order=time으로 호출됐는지 확인
+    expect(listMock.mock.calls[0][0]).toMatchObject({ order: 'time', videoId: 'video-xyz' });
+  });
+
+  it('publishedAt<=since 발견 시 즉시 종료(후속 페이지 호출 없음)', async () => {
+    listMock.mockResolvedValueOnce({
+      data: {
+        items: [mkThread('5', '2026-04-21T11:00:00Z'), mkThread('4', '2026-04-20T09:00:00Z')],
+        nextPageToken: 'PAGE2',
+      },
+    });
+
+    const collector = new YoutubeCommentsCollector();
+    const collected: string[] = [];
+    for await (const chunk of collector.collect({
+      keyword: 'video-xyz',
+      startDate: '2026-04-01T00:00:00Z',
+      endDate: '2026-04-30T00:00:00Z',
+      maxComments: 100,
+      since: '2026-04-20T12:00:00Z',
+      commentOrder: 'time',
+    })) {
+      for (const c of chunk) collected.push(c.sourceId);
+    }
+    expect(collected).toEqual(['5']);
+    // since cutoff 감지되면 다음 페이지 호출하지 않음
+    expect(listMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('since 미지정 시 기존 order=relevance 동작 유지', async () => {
+    listMock.mockResolvedValueOnce({
+      data: { items: [mkThread('1', '2026-04-21T10:00:00Z')], nextPageToken: undefined },
+    });
+    const collector = new YoutubeCommentsCollector();
+    for await (const _ of collector.collect({
+      keyword: 'video-xyz',
+      startDate: '2026-04-01T00:00:00Z',
+      endDate: '2026-04-30T00:00:00Z',
+      maxComments: 100,
+    })) {
+      // drain
+    }
+    expect(listMock.mock.calls[0][0]).toMatchObject({ order: 'relevance' });
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors test -- youtube-comments.incremental`
+Expected: 3건 모두 FAIL — since 해석 미구현.
+
+---
+
+## Task 8: YoutubeCommentsCollector — since 지원 구현
+
+**Files:**
+
+- Modify: `packages/collectors/src/adapters/youtube-comments.ts:36-121`
+
+- [ ] **Step 1: collect 메서드 구현 교체**
+
+```typescript
+async *collect(options: CollectionOptions): AsyncGenerator<YoutubeComment[], void, unknown> {
+  const youtube = getYoutubeClient();
+  const videoId = options.keyword;
+  const maxComments = options.maxComments ?? DEFAULT_MAX_COMMENTS;
+  const since = options.since ? new Date(options.since) : null;
+  // since가 있으면 order=time 강제 (최신순 필수), 없으면 options.commentOrder 또는 relevance
+  const order: 'time' | 'relevance' = since ? 'time' : (options.commentOrder ?? 'relevance');
+
+  let totalCollected = 0;
+  let nextPageToken: string | undefined;
+
+  pageLoop: while (totalCollected < maxComments) {
+    try {
+      const response = await youtube.commentThreads.list({
+        part: ['snippet', 'replies'],
+        videoId,
+        maxResults: Math.min(maxComments - totalCollected, COMMENTS_PAGE_SIZE),
+        order,
+        pageToken: nextPageToken,
+      });
+
+      const items = response.data.items;
+      if (!items || items.length === 0) break;
+
+      const comments: YoutubeComment[] = [];
+      let stopDueToSince = false;
+
+      for (const thread of items) {
+        const topComment = thread.snippet?.topLevelComment;
+        if (!topComment?.snippet) continue;
+
+        const publishedAt: Date | null = topComment.snippet.publishedAt
+          ? new Date(topComment.snippet.publishedAt)
+          : null;
+
+        // since cutoff: 최신순 정렬 상태에서 오래된 것 발견 → 이후는 모두 더 오래됨 → 즉시 종료
+        if (since && publishedAt && publishedAt.getTime() <= since.getTime()) {
+          stopDueToSince = true;
+          break;
+        }
+
+        comments.push({
+          sourceId: topComment.id ?? '',
+          parentId: null,
+          videoSourceId: videoId,
+          content: topComment.snippet.textDisplay ?? '',
+          author: topComment.snippet.authorDisplayName ?? '',
+          likeCount: topComment.snippet.likeCount ?? 0,
+          publishedAt,
+          rawData: topComment as unknown as Record<string, unknown>,
+        });
+
+        if (thread.replies?.comments) {
+          for (const reply of thread.replies.comments) {
+            if (!reply.snippet) continue;
+            const replyPublishedAt: Date | null = reply.snippet.publishedAt
+              ? new Date(reply.snippet.publishedAt)
+              : null;
+            if (since && replyPublishedAt && replyPublishedAt.getTime() <= since.getTime()) {
+              continue;
+            }
+            comments.push({
+              sourceId: reply.id ?? '',
+              parentId: topComment.id ?? null,
+              videoSourceId: videoId,
+              content: reply.snippet.textDisplay ?? '',
+              author: reply.snippet.authorDisplayName ?? '',
+              likeCount: reply.snippet.likeCount ?? 0,
+              publishedAt: replyPublishedAt,
+              rawData: reply as unknown as Record<string, unknown>,
+            });
+          }
+        }
+      }
+
+      if (comments.length > 0) {
+        totalCollected += comments.length;
+        yield comments;
+      }
+
+      if (stopDueToSince) break pageLoop;
+
+      nextPageToken = response.data.nextPageToken ?? undefined;
+      if (!nextPageToken) break;
+    } catch (err: unknown) {
+      const error = err as { code?: number; message?: string };
+      if (error.code === 403) break; // 댓글 비활성화 영상
+      throw err;
+    }
+  }
+}
+```
+
+- [ ] **Step 2: 테스트 통과 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors test -- youtube-comments.incremental`
+Expected: 3건 PASS.
+
+- [ ] **Step 3: 기존 youtube 관련 테스트 회귀 없음 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors test -- youtube`
+Expected: 전부 PASS.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add packages/collectors/src/adapters/youtube-comments.ts \
+        packages/collectors/src/adapters/__tests__/youtube-comments.incremental.test.ts
+git commit -m "feat(collectors): YouTube 댓글 어댑터 증분 수집 지원
+
+- CollectionOptions.since 해석, publishedAt<=since 발견 시 조기 종료
+- since 지정 시 order=time 강제(최신순 필수)
+- 대댓글도 since 필터 적용
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: reuse-planner — RefetchCommentSpec 타입 신설 (테스트 먼저)
+
+**Files:**
+
+- Create: `packages/core/src/pipeline/__tests__/reuse-planner.refetch-spec.test.ts`
+
+- [ ] **Step 1: 기존 reuse-planner 테스트 위치 확인**
+
+Run: `rg -l "planArticleReuse|reuse-planner" packages/core/src --type ts`
+Expected: `reuse-planner.ts`와 기존 테스트 파일 위치 확인. 신규 테스트는 별도 파일로.
+
+- [ ] **Step 2: 실패하는 테스트 작성**
+
+```typescript
+// packages/core/src/pipeline/__tests__/reuse-planner.refetch-spec.test.ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { planArticleReuse, type ArticleReusePlan } from '../reuse-planner';
+import { getDb } from '../../db';
+import { articles, articleKeywords } from '../../db/schema/collections';
+
+describe('planArticleReuse refetchCommentsFor 반환 구조', () => {
+  const now = new Date();
+  const TEST_KEYWORD = 'test-refetch-spec';
+
+  beforeAll(async () => {
+    const db = getDb();
+    const inserted = await db
+      .insert(articles)
+      .values({
+        source: 'naver-news',
+        sourceId: 'rfspec-1',
+        url: 'https://n.news.naver.com/article/001/rfspec1',
+        title: 't',
+        content: 'c',
+        publishedAt: new Date(now.getTime() - 1000 * 60 * 60),
+        lastFetchedAt: new Date(now.getTime() - 1000 * 60 * 60),
+        lastCommentsFetchedAt: new Date(now.getTime() - 1000 * 60 * 60 * 48),
+      })
+      .returning();
+    await db
+      .insert(articleKeywords)
+      .values({ articleId: inserted[0].id, keyword: TEST_KEYWORD })
+      .onConflictDoNothing();
+  });
+
+  afterAll(async () => {
+    const db = getDb();
+    await db
+      .delete(articleKeywords)
+      .where(/* match TEST_KEYWORD */ { keyword: TEST_KEYWORD } as any);
+  });
+
+  it('refetchCommentsFor의 각 항목이 RefetchCommentSpec 형태를 갖는다', async () => {
+    const plan: ArticleReusePlan = await planArticleReuse({
+      source: 'naver-news',
+      keyword: TEST_KEYWORD,
+      startDate: new Date(now.getTime() - 1000 * 60 * 60 * 24),
+      endDate: new Date(now.getTime() + 1000 * 60 * 60),
+    });
+    expect(plan.refetchCommentsFor.length).toBeGreaterThanOrEqual(1);
+    const spec = plan.refetchCommentsFor[0];
+    expect(spec).toHaveProperty('url');
+    expect(spec).toHaveProperty('articleId');
+    expect(spec).toHaveProperty('lastCommentsFetchedAt');
+    expect(typeof spec.url).toBe('string');
+    expect(typeof spec.articleId).toBe('number');
+  });
+});
+```
+
+> **주의**: 이 테스트는 실제 DB(개발 ais-prod-postgres:5438)를 건드린다. 기존 core 테스트가 DB mocking 없이 돌고 있으면 그 규약을 따른다. mocking 패턴이 기본이면 메모리 레포지토리 fake로 대체.
+
+실제 리포지토리 패턴을 먼저 확인:
+
+Run: `rg -l "getDb|vi.mock.*db" packages/core/src/pipeline/__tests__ packages/core/src/analysis/__tests__ | head -5`
+
+확인된 패턴에 맞춰 Step 2를 조정. 기존 패턴이 없다면 이 Task를 **단위 테스트로 전환**하고 planArticleReuse 대신 RefetchCommentSpec 타입의 존재만 확인하는 타입 체크 테스트로 대체:
+
+```typescript
+// fallback: 타입 존재 확인 테스트
+import type { RefetchCommentSpec, ArticleReusePlan } from '../reuse-planner';
+it('RefetchCommentSpec 타입이 필수 필드를 갖는다', () => {
+  const spec: RefetchCommentSpec = {
+    url: 'x',
+    articleId: 1,
+    lastCommentsFetchedAt: null,
+  };
+  const plan: ArticleReusePlan = {
+    reuseArticleIds: [],
+    skipUrls: [],
+    refetchCommentsFor: [spec],
+    evaluated: 0,
+  };
+  expect(plan.refetchCommentsFor[0].articleId).toBe(1);
+});
+```
+
+- [ ] **Step 3: 실패 확인**
+
+Run: `pnpm --filter @ai-signalcraft/core test -- reuse-planner.refetch-spec`
+Expected: FAIL — `RefetchCommentSpec` export 없음, 또는 `refetchCommentsFor` 타입 불일치.
+
+---
+
+## Task 10: reuse-planner — RefetchCommentSpec 타입 구현
+
+**Files:**
+
+- Modify: `packages/core/src/pipeline/reuse-planner.ts:21-48, 99-122, 160-185`
+- Modify: `packages/core/src/types/pipeline.ts` 또는 `packages/core/src/types/index.ts` (ReusePlanPayload 정의 위치)
+
+- [ ] **Step 1: ReusePlanPayload 정의 위치 확인**
+
+Run: `rg -n "ReusePlanPayload" packages/core/src --type ts`
+Expected: 정의 파일 1곳 + 사용 파일 여러 곳. 정의 파일을 먼저 식별.
+
+- [ ] **Step 2: RefetchCommentSpec 타입 추가 및 ArticleReusePlan/VideoReusePlan 변경**
+
+`packages/core/src/pipeline/reuse-planner.ts`의 타입 정의 블록 교체:
+
+```typescript
+export interface RefetchCommentSpec {
+  url: string;
+  articleId: number;
+  lastCommentsFetchedAt: Date | null;
+}
+
+export interface RefetchCommentSpecVideo {
+  url: string;
+  videoId: number;
+  lastCommentsFetchedAt: Date | null;
+}
+
+export interface ArticleReusePlan {
+  reuseArticleIds: number[];
+  skipUrls: string[];
+  refetchCommentsFor: RefetchCommentSpec[];
+  evaluated: number;
+}
+
+export interface VideoReusePlan {
+  reuseVideoIds: number[];
+  skipVideoUrls: string[];
+  refetchCommentsFor: RefetchCommentSpecVideo[];
+  evaluated: number;
+}
+
+const EMPTY_ARTICLE_PLAN: ArticleReusePlan = {
+  reuseArticleIds: [],
+  skipUrls: [],
+  refetchCommentsFor: [],
+  evaluated: 0,
+};
+
+const EMPTY_VIDEO_PLAN: VideoReusePlan = {
+  reuseVideoIds: [],
+  skipVideoUrls: [],
+  refetchCommentsFor: [],
+  evaluated: 0,
+};
+```
+
+- [ ] **Step 3: planArticleReuse/planVideoReuse 반환값 구성 변경**
+
+`planArticleReuse`의 `refetchCommentsFor.push(row.url)` 부분을 교체:
+
+```typescript
+for (const row of candidates) {
+  reuseArticleIds.push(row.id);
+  const commentsStale =
+    !row.lastCommentsFetchedAt || row.lastCommentsFetchedAt.getTime() < commentCutoffMs;
+  if (commentsStale) {
+    refetchCommentsFor.push({
+      url: row.url,
+      articleId: row.id,
+      lastCommentsFetchedAt: row.lastCommentsFetchedAt ?? null,
+    });
+  } else {
+    skipUrls.push(row.url);
+  }
+}
+```
+
+`planVideoReuse`도 동일 패턴으로 videoId 필드 사용:
+
+```typescript
+for (const row of candidates) {
+  reuseVideoIds.push(row.id);
+  const commentsStale =
+    !row.lastCommentsFetchedAt || row.lastCommentsFetchedAt.getTime() < commentCutoffMs;
+  if (commentsStale) {
+    refetchCommentsFor.push({
+      url: row.url,
+      videoId: row.id,
+      lastCommentsFetchedAt: row.lastCommentsFetchedAt ?? null,
+    });
+  } else {
+    skipVideoUrls.push(row.url);
+  }
+}
+```
+
+- [ ] **Step 4: 타입 체크 — 상위 호출자 영향 파악**
+
+Run: `pnpm -w typecheck` 또는 `pnpm --filter @ai-signalcraft/core build`
+Expected: `flows.ts`에서 `plan.refetchCommentsFor` 또는 `toReusePlanPayload`가 `string[]`으로 기대하는 곳에서 에러. **이게 다음 Task의 출발점**.
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `pnpm --filter @ai-signalcraft/core test -- reuse-planner.refetch-spec`
+Expected: PASS (타입 테스트) — 단, 다른 곳 타입 에러로 전체 테스트 실행 실패할 수 있음. 그 경우 Task 11 후에 재확인.
+
+- [ ] **Step 6: 커밋 (타입 에러 잔존 허용 — 다음 Task에서 해소)**
+
+```bash
+git add packages/core/src/pipeline/reuse-planner.ts \
+        packages/core/src/pipeline/__tests__/reuse-planner.refetch-spec.test.ts
+git commit -m "feat(core): RefetchCommentSpec 타입 도입 — 댓글 증분 수집용
+
+articleId/videoId/lastCommentsFetchedAt을 번들로 전달하도록
+refetchCommentsFor를 객체 배열로 승격. 호출자 영향은 후속 커밋에서 해소.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: flows.ts — ReusePlanPayload 및 since 전달
+
+**Files:**
+
+- Modify: `packages/core/src/queue/flows.ts:100-106` (`toReusePlanPayload` 근처)
+- Modify: `packages/core/src/types/pipeline.ts` (ReusePlanPayload 정의)
+
+- [ ] **Step 1: ReusePlanPayload 정의 변경**
+
+`packages/core/src/types/pipeline.ts`에서 `ReusePlanPayload`를 찾아 `refetchCommentsFor` 타입을 다음과 같이 수정:
+
+```typescript
+export interface ReusePlanPayload {
+  skipUrls: string[];
+  refetchCommentsFor: Array<{
+    url: string;
+    // articleId/videoId 중 하나만 세팅 (수집 계통이 다른 두 테이블 구분)
+    articleId?: number;
+    videoId?: number;
+    lastCommentsFetchedAt: string | null; // BullMQ 직렬화를 고려해 ISO 문자열로 전달
+  }>;
+}
+```
+
+> 실제 필드명이 다를 수 있음 — Step 0에서 확인한 파일 내용에 맞춰 조정.
+
+- [ ] **Step 2: `toReusePlanPayload` 어댑터 교체**
+
+`packages/core/src/queue/flows.ts`:
+
+```typescript
+function toReusePlanPayload(plan: ArticleReusePlan | VideoReusePlan): ReusePlanPayload {
+  const skipUrls = 'skipUrls' in plan ? plan.skipUrls : plan.skipVideoUrls;
+  const refetchCommentsFor = plan.refetchCommentsFor.map((spec) => ({
+    url: spec.url,
+    ...('articleId' in spec ? { articleId: spec.articleId } : {}),
+    ...('videoId' in spec ? { videoId: spec.videoId } : {}),
+    lastCommentsFetchedAt: spec.lastCommentsFetchedAt
+      ? spec.lastCommentsFetchedAt.toISOString()
+      : null,
+  }));
+  return { skipUrls, refetchCommentsFor };
+}
+```
+
+- [ ] **Step 3: 타입 체크**
+
+Run: `pnpm --filter @ai-signalcraft/core build`
+Expected: `core` 단위 타입 에러 없음.
+
+- [ ] **Step 4: collectors쪽 CollectionOptions reusePlan 스키마 업데이트**
+
+`packages/collectors/src/adapters/base.ts`의 `CollectionOptionsSchema.reusePlan`:
+
+```typescript
+reusePlan: z
+  .object({
+    skipUrls: z.array(z.string()).default([]),
+    refetchCommentsFor: z
+      .array(
+        z.object({
+          url: z.string(),
+          articleId: z.number().int().optional(),
+          videoId: z.number().int().optional(),
+          lastCommentsFetchedAt: z.string().datetime().nullable(),
+        }),
+      )
+      .default([]),
+  })
+  .optional(),
+```
+
+- [ ] **Step 5: CommunityBaseCollector의 refetchCommentsFor 사용부 업데이트**
+
+`packages/collectors/src/adapters/community-base-collector.ts:92-93`:
+
+```typescript
+// 기존: const refetchCommentsOnlySet = new Set(options.reusePlan?.refetchCommentsFor ?? []);
+const refetchCommentsOnlySet = new Set(
+  (options.reusePlan?.refetchCommentsFor ?? []).map((s) => s.url),
+);
+```
+
+- [ ] **Step 6: collectors 빌드·테스트 회귀 없음 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors build && pnpm --filter @ai-signalcraft/collectors test`
+Expected: 전부 PASS.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add packages/core/src/types/pipeline.ts \
+        packages/core/src/queue/flows.ts \
+        packages/collectors/src/adapters/base.ts \
+        packages/collectors/src/adapters/community-base-collector.ts
+git commit -m "refactor: ReusePlanPayload.refetchCommentsFor를 객체 배열로 확장
+
+URL뿐 아니라 articleId/videoId/lastCommentsFetchedAt을 어댑터까지 전달.
+커뮤니티 어댑터는 기존처럼 url만 사용 (증분 미적용).
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: pipeline-worker — 네이버/유튜브 댓글 수집부에 since 전달
+
+**Files:**
+
+- Modify: `packages/core/src/queue/pipeline-worker.ts:100-177` (naver 댓글 수집부)
+- Modify: `packages/core/src/queue/collector-worker.ts` (YouTube collect 경로에 since 주입)
+
+- [ ] **Step 1: 네이버 댓글 since 맵 구성**
+
+`pipeline-worker.ts`의 `normalize-naver` 분기에서 `reusePlan` 정보를 받아 URL→lastCommentsFetchedAt 맵 구성.
+
+`normalize-naver` 진입부 (articles 변수 초기화 직후):
+
+```typescript
+// reusePlan의 refetchCommentsFor에서 URL→since 매핑 추출
+const refetchSpecs = (job.data.reusePlan?.refetchCommentsFor ?? []) as Array<{
+  url: string;
+  lastCommentsFetchedAt: string | null;
+}>;
+const urlToSince = new Map<string, Date | null>(
+  refetchSpecs.map((s) => [
+    s.url,
+    s.lastCommentsFetchedAt ? new Date(s.lastCommentsFetchedAt) : null,
+  ]),
+);
+```
+
+> `normalize-naver`가 `job.data.reusePlan`을 받지 않고 있다면 flows.ts에서 해당 필드를 normalize 노드 data에도 포함시켜야 함. Step 1.5로 추가 작업.
+
+- [ ] **Step 1.5: flows.ts에서 normalize 노드 data에 reusePlan 포함 여부 확인**
+
+Run: `rg -n "normalize-naver|normalize-youtube" packages/core/src/queue/flows.ts -A 10 | grep -E "reusePlan|data:"`
+Expected: 기존에 `reusePlan`이 collect 노드 data에만 전달되고 있다면, normalize 노드 data에도 포함하도록 flows.ts 수정:
+
+```typescript
+// flows.ts의 naver children[0] (normalize 노드):
+children.push({
+  name: 'normalize-naver',
+  queueName: 'pipeline',
+  data: {
+    source: 'naver-news',
+    flowId,
+    dbJobId,
+    maxComments: limits.commentsPerItem,
+    reusePlan,    // ← 추가
+  },
+  children: [...],
+});
+```
+
+- [ ] **Step 2: 네이버 댓글 수집 루프에서 since 전달**
+
+`pipeline-worker.ts:116-135`의 `collectArticleComments` 함수에서:
+
+```typescript
+const collectArticleComments = async (item: { index: number; url: string }) => {
+  const detail = articleDetails[item.index];
+  detail.status = 'running';
+  const collector = new NaverCommentsCollector();
+  const articleComments: NaverComment[] = [];
+  const since = urlToSince.get(item.url) ?? undefined;
+
+  try {
+    for await (const chunk of collector.collectForArticle(item.url, {
+      maxComments,
+      since: since ?? undefined,
+    })) {
+      articleComments.push(...chunk);
+      detail.comments = articleComments.length;
+      await updateProgress();
+    }
+    detail.status = 'completed';
+  } catch (err) {
+    logger.warn(`댓글 수집 실패 (${item.url}):`, err);
+    detail.status = 'failed';
+  }
+  return articleComments;
+};
+```
+
+- [ ] **Step 3: YouTube collect 경로에 since 전달**
+
+YouTube는 `youtube-collector.ts`(통합 수집기)가 CollectionOptions를 받는 경로. `flows.ts`의 `collect-youtube` 노드 data 작성 부분에서, `since`가 reusePlan 기반으로 결정되지 않으므로 **video 단위 since는 별도 처리**가 필요하다.
+
+현실적 절충안: YouTube는 일체형 수집기가 videoId 리스트를 먼저 뽑고 각 영상 댓글을 내부적으로 수집. 영상별 since는 수집기 진입점에서 DB 조회(`videos.lastCommentsFetchedAt`)로 해결하는 방식을 택한다.
+
+`packages/collectors/src/adapters/youtube-collector.ts`의 영상 댓글 수집 단계(영상별 반복 내부)에서 `YoutubeCommentsCollector.collect` 호출 시 `options.since`를 다음과 같이 주입:
+
+```typescript
+// 영상별 댓글 수집 루프 안 (YoutubeCollector 내부)
+for (const video of videos) {
+  const since = videoUrlToSince?.get(video.url) ?? undefined;
+  const commentsCollector = new YoutubeCommentsCollector();
+  for await (const chunk of commentsCollector.collect({
+    ...baseOptions,
+    keyword: video.sourceId,
+    since,
+  })) {
+    // ...
+  }
+}
+```
+
+위에서 `videoUrlToSince`는 `options.reusePlan?.refetchCommentsFor`에서 같은 방식으로 구성한다. 이 맵은 YoutubeCollector 생성 시 options에서 한 번만 빌드.
+
+> **주의**: YoutubeCollector 내부 구조는 실제 파일 확인이 필요함. 위 스니펫은 패턴 예시이므로, `youtube-collector.ts`의 현재 댓글 수집 호출 지점을 찾아 동일 원칙으로 since 주입.
+
+Run: `rg -n "YoutubeCommentsCollector|collectForVideo|commentsCollector" packages/collectors/src/adapters/youtube-collector.ts`
+확인한 실제 위치에 since 주입 코드 적용.
+
+- [ ] **Step 4: 빌드/기존 테스트 회귀 없음 확인**
+
+Run: `pnpm -w build && pnpm -w test`
+Expected: 전부 PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add packages/core/src/queue/pipeline-worker.ts \
+        packages/core/src/queue/flows.ts \
+        packages/collectors/src/adapters/youtube-collector.ts
+git commit -m "feat(pipeline): 네이버/유튜브 댓글 수집부에 since 주입
+
+reusePlan.refetchCommentsFor의 lastCommentsFetchedAt을 URL별 Map으로 변환 후
+각 어댑터 호출 시 since로 전달. normalize-naver 노드 data에 reusePlan 필드 추가.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: analyzeItems — 증분 필터 + skipped 카운트 (테스트 먼저)
+
+**Files:**
+
+- Create: `packages/core/src/analysis/__tests__/item-analyzer.incremental.test.ts`
+
+- [ ] **Step 1: 기존 item-analyzer 테스트 패턴 확인**
+
+Run: `rg -l "sentiment-classifier|classifySentiment|analyzeItems" packages/core/src --type ts`
+Expected: analyzer와 classifier 모킹 패턴 확인.
+
+- [ ] **Step 2: 실패하는 단위 테스트 작성**
+
+`classifySentiment`와 DB를 모킹하는 것이 현실적. 다음은 **classify 호출 횟수**만 검증하는 최소 테스트:
+
+```typescript
+// packages/core/src/analysis/__tests__/item-analyzer.incremental.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SentimentResult } from '../sentiment-classifier';
+
+// classifier를 모킹해 호출 횟수만 관찰
+const classifyMock = vi.fn(
+  async (texts: string[]): Promise<SentimentResult[]> =>
+    texts.map(() => ({ label: 'neutral' as const, score: 0.5 })),
+);
+vi.mock('../sentiment-classifier', () => ({
+  classifySentiment: (texts: string[]) => classifyMock(texts),
+  initClassifier: async () => {},
+}));
+
+// DB는 실제로 안 부르고 analyzeItems를 얇게 래핑한 테스트 버전을 import
+// 실제 구현: analyzeItems가 isNull(sentiment)로 필터하는지를 DB 모킹 테스트로 검증
+// 대체: 쿼리 구성을 별도 헬퍼로 분리하고 그 헬퍼를 검증
+
+import { buildItemAnalysisQueries } from '../item-analyzer';
+
+describe('analyzeItems 증분 쿼리', () => {
+  beforeEach(() => classifyMock.mockClear());
+
+  it('쿼리 빌더가 articles/comments에 대해 isNull(sentiment) 조건을 포함한다', () => {
+    const { articleQuery, commentQuery } = buildItemAnalysisQueries(123);
+    // drizzle 쿼리 객체를 toSQL()로 검증
+    const artSql = articleQuery.toSQL();
+    const cmtSql = commentQuery.toSQL();
+    expect(artSql.sql).toMatch(/articles.*"sentiment" is null/i);
+    expect(cmtSql.sql).toMatch(/comments.*"sentiment" is null/i);
+  });
+});
+```
+
+> 위 테스트는 **Task 14에서 `buildItemAnalysisQueries`를 export로 추출**하는 것을 전제. Task 14의 구현이 이 export를 만든다.
+
+- [ ] **Step 3: 실패 확인**
+
+Run: `pnpm --filter @ai-signalcraft/core test -- item-analyzer.incremental`
+Expected: FAIL — `buildItemAnalysisQueries` export 없음.
+
+---
+
+## Task 14: analyzeItems 증분 구현
+
+**Files:**
+
+- Modify: `packages/core/src/analysis/item-analyzer.ts:80-226`
+
+- [ ] **Step 1: 쿼리 빌더 분리 + isNull 필터**
+
+`packages/core/src/analysis/item-analyzer.ts`의 상단 import에 `isNull` 추가:
+
+```typescript
+import { and, eq, isNull, sql } from 'drizzle-orm';
+```
+
+`analyzeItems` 함수의 articleRows/commentRows 로드 부분을 별도 함수로 추출하고 export:
+
+```typescript
+export function buildItemAnalysisQueries(jobId: number) {
+  const db = getDb();
+  const articleQuery = db
+    .select({ id: articles.id, title: articles.title, content: articles.content })
+    .from(articles)
+    .innerJoin(articleJobs, eq(articles.id, articleJobs.articleId))
+    .where(and(eq(articleJobs.jobId, jobId), isNull(articles.sentiment)));
+  const commentQuery = db
+    .select({ id: comments.id, content: comments.content })
+    .from(comments)
+    .innerJoin(commentJobs, eq(comments.id, commentJobs.commentId))
+    .where(and(eq(commentJobs.jobId, jobId), isNull(comments.sentiment)));
+  return { articleQuery, commentQuery };
+}
+```
+
+`analyzeItems` 내부는 이렇게 호출로 바꾼다:
+
+```typescript
+const { articleQuery, commentQuery } = buildItemAnalysisQueries(jobId);
+const [articleRows, commentRows] = await Promise.all([articleQuery, commentQuery]);
+```
+
+- [ ] **Step 2: skipped 카운트 계산**
+
+전체 개수와 "이미 분류됨 개수"를 별도 쿼리로 얻어 progress JSON에 포함.
+
+`analyzeItems` 함수 상단 (articleRows 로드 직후) 추가:
+
+```typescript
+// skipped 개수 — 해당 jobId에 연결된 전체 중 sentiment 이미 있는 것
+const [articlesSkipped, commentsSkipped] = await Promise.all([
+  db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(articles)
+    .innerJoin(articleJobs, eq(articles.id, articleJobs.articleId))
+    .where(and(eq(articleJobs.jobId, jobId), sql`${articles.sentiment} IS NOT NULL`))
+    .then((rows) => rows[0]?.count ?? 0),
+  db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(comments)
+    .innerJoin(commentJobs, eq(comments.id, commentJobs.commentId))
+    .where(and(eq(commentJobs.jobId, jobId), sql`${comments.sentiment} IS NOT NULL`))
+    .then((rows) => rows[0]?.count ?? 0),
+]);
+
+const articlesTotal = articleRows.length + articlesSkipped;
+const commentsTotal = commentRows.length + commentsSkipped;
+```
+
+기존 `articlesTotal = articleRows.length` / `commentsTotal = commentRows.length` 라인은 제거.
+
+- [ ] **Step 3: progress에 skipped 필드 포함**
+
+`updateJobProgress(jobId, { 'item-analysis': {...} })` 호출 3곳(시작/청크별/완료) 모두에서 `articlesSkipped`, `commentsSkipped`를 포함:
+
+```typescript
+await updateJobProgress(jobId, {
+  'item-analysis': {
+    status: 'running',
+    phase: 'lightweight',
+    articlesTotal,
+    commentsTotal,
+    articlesAnalyzed,
+    commentsAnalyzed,
+    articlesSkipped,
+    commentsSkipped,
+  },
+});
+```
+
+- [ ] **Step 4: 이벤트 로그 문구 보완**
+
+`appendJobEvent` 시작 시점 문구:
+
+```typescript
+await appendJobEvent(
+  jobId,
+  'info',
+  `개별 감정 분석 시작 (신규: 기사 ${articleRows.length}건, 댓글 ${commentRows.length}건, 이미 분류됨: 기사 ${articlesSkipped}건, 댓글 ${commentsSkipped}건)`,
+);
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `pnpm --filter @ai-signalcraft/core test -- item-analyzer.incremental`
+Expected: PASS.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add packages/core/src/analysis/item-analyzer.ts \
+        packages/core/src/analysis/__tests__/item-analyzer.incremental.test.ts
+git commit -m "feat(analysis): item-analyzer 증분화 — sentiment IS NULL 필터
+
+- buildItemAnalysisQueries 헬퍼 추출
+- 이미 분류된 row는 BERT 재호출 스킵
+- progress에 articlesSkipped/commentsSkipped 필드 추가
+- Stage 0 호출은 이중 안전망으로 유지 (멱등)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: triggerClassify + classify 노드 핸들러
+
+**Files:**
+
+- Modify: `packages/core/src/queue/flows.ts:458-488`
+- Modify: `packages/core/src/queue/pipeline-worker.ts:527-530` (triggerAnalysis 호출부)
+- Create: `packages/core/src/queue/__tests__/triggerClassify.test.ts`
+
+- [ ] **Step 1: triggerClassify 추가**
+
+`packages/core/src/queue/flows.ts`의 파일 끝부분 (`triggerAnalysisResume` 뒤)에 추가:
+
+```typescript
+// 개별 감정 분류 트리거 — persist 완료 후 호출
+// classify 완료 시 triggerAnalysis를 자동으로 이어서 호출한다
+export async function triggerClassify(dbJobId: number, keyword: string) {
+  const flow = await getFlowProducer().add({
+    name: 'classify',
+    queueName: 'pipeline',
+    data: { dbJobId, keyword },
+    opts: {
+      removeOnComplete: { age: 3600 },
+      removeOnFail: { age: 86400 },
+    },
+  });
+  return flow;
+}
+```
+
+- [ ] **Step 2: persist 핸들러에서 triggerAnalysis → triggerClassify**
+
+`packages/core/src/queue/pipeline-worker.ts`의 persist 분기 말미:
+
+```typescript
+// 기존: await triggerAnalysis(dbJobId, keyword);
+await triggerClassify(dbJobId, keyword);
+logger.info(`classify 노드 트리거됨: job=${dbJobId}, keyword=${keyword}`);
+```
+
+상단 import 변경:
+
+```typescript
+// import { triggerAnalysis } from './flows';   ← 제거
+import { triggerAnalysis, triggerClassify } from './flows';
+```
+
+> `triggerAnalysis`는 classify 분기 안에서 여전히 사용되므로 import 유지.
+
+- [ ] **Step 3: classify 분기 추가**
+
+`packages/core/src/queue/pipeline-worker.ts`의 handler 함수 내부, 기존 `if (job.name.startsWith('normalize-'))` 블록과 `persist` 블록 사이(혹은 뒤)에 추가:
+
+```typescript
+if (job.name === 'classify') {
+  const { dbJobId, keyword } = job.data;
+
+  if (await isPipelineCancelled(dbJobId)) {
+    logger.info(`[classify] 취소됨 — 스킵 (dbJobId=${dbJobId})`);
+    return { skipped: true, reason: 'cancelled' };
+  }
+
+  // 증분 개별 감정 분석 — 실패해도 분석은 계속
+  try {
+    await analyzeItems(dbJobId);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`[classify] item-analysis 실패 (분석은 계속): ${msg}`);
+    await appendJobEvent(dbJobId, 'warn', `개별 감정 분석 실패 (분석은 계속 진행됨): ${msg}`).catch(
+      () => void 0,
+    );
+  }
+
+  // 게이트 확인
+  if (!(await awaitStageGate(dbJobId, 'normalize'))) {
+    logger.info(`[classify] 게이트 미통과 — 분석 트리거 건너뜀 (dbJobId=${dbJobId})`);
+    return { cancelled: true };
+  }
+
+  if (keyword) {
+    await triggerAnalysis(dbJobId, keyword);
+    logger.info(`[classify] 분석 파이프라인 트리거됨: job=${dbJobId}, keyword=${keyword}`);
+  }
+  return { classified: true };
+}
+```
+
+상단 import에 `analyzeItems`, `appendJobEvent` 추가(없다면):
+
+```typescript
+import { analyzeItems } from '../analysis/item-analyzer';
+import {
+  // ... 기존 import ...
+  appendJobEvent,
+} from '../pipeline';
+```
+
+- [ ] **Step 4: 단위 테스트 — triggerClassify가 올바른 name/queueName으로 add한다**
+
+```typescript
+// packages/core/src/queue/__tests__/triggerClassify.test.ts
+import { describe, it, expect, vi } from 'vitest';
+
+const addMock = vi.fn().mockResolvedValue({ id: 'flow-1' });
+vi.mock('bullmq', () => ({
+  FlowProducer: class {
+    add(...args: unknown[]) {
+      return addMock(...args);
+    }
+  },
+}));
+
+import { triggerClassify } from '../flows';
+
+describe('triggerClassify', () => {
+  it('classify name + pipeline 큐로 flow 추가한다', async () => {
+    await triggerClassify(42, 'foo');
+    expect(addMock).toHaveBeenCalledTimes(1);
+    const arg = addMock.mock.calls[0][0];
+    expect(arg.name).toBe('classify');
+    expect(arg.queueName).toBe('pipeline');
+    expect(arg.data).toMatchObject({ dbJobId: 42, keyword: 'foo' });
+  });
+});
+```
+
+Run: `pnpm --filter @ai-signalcraft/core test -- triggerClassify`
+Expected: PASS.
+
+- [ ] **Step 5: 전체 빌드·테스트**
+
+Run: `pnpm -w build && pnpm -w test`
+Expected: 전부 PASS.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add packages/core/src/queue/flows.ts \
+        packages/core/src/queue/pipeline-worker.ts \
+        packages/core/src/queue/__tests__/triggerClassify.test.ts
+git commit -m "feat(queue): classify 큐 노드 추가 — 개별 감정 분류를 수집 단계로 이동
+
+- triggerClassify() 헬퍼 추가 (pipeline 큐 재사용, job.name='classify')
+- persist 말미에서 triggerAnalysis → triggerClassify로 교체
+- classify 핸들러는 analyzeItems 호출 후 triggerAnalysis를 이어서 실행
+- BERT 실패해도 분석은 sentiment=NULL 상태로 진행 (실패 격리)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 16: 통합 동작 수동 검증 (개발 환경)
+
+**Files:** 없음 (운영 플로우 검증)
+
+- [ ] **Step 1: 개발 워커 재시작**
+
+Run: `pnpm worker` (개발 셸) 또는 `pnpm dev:all`
+Expected: `pipeline` 큐 핸들러에 classify 분기가 실린 채로 기동.
+
+- [ ] **Step 2: 새 수집 트리거 — 신규 키워드**
+
+UI 또는 스크립트로 새 키워드 "이재명-증분검증" 수집 실행. 일자 범위는 어제~오늘, 소스는 naver + youtube만.
+
+- [ ] **Step 3: classify 노드 실행 로그 확인**
+
+Run (워커 로그): `dserver logs ais-collector-worker --tail=200` 또는 개발 셸 stdout
+Expected: `[classify] 분석 파이프라인 트리거됨: job=<N>` 로그 1회.
+
+- [ ] **Step 4: DB에서 first_seen_at 검증**
+
+```bash
+psql <dev-dsn> -c "
+  SELECT source, count(*),
+         min(first_seen_at) AS oldest_seen,
+         max(first_seen_at) AS newest_seen,
+         min(collected_at) AS oldest_collected
+  FROM comments
+  WHERE job_id = (SELECT max(id) FROM collection_jobs WHERE keyword='이재명-증분검증')
+  GROUP BY source;
+"
+```
+
+Expected: `oldest_seen`과 `oldest_collected`가 거의 같음 (첫 수집이라).
+
+- [ ] **Step 5: 같은 키워드로 2회차 수집 실행 (TTL 내)**
+
+2회차 수집 후:
+
+```bash
+psql <dev-dsn> -c "
+  SELECT c.source, count(*) AS total,
+         sum(CASE WHEN c.first_seen_at < now() - interval '5 minutes' THEN 1 ELSE 0 END) AS reused,
+         sum(CASE WHEN c.first_seen_at >= now() - interval '5 minutes' THEN 1 ELSE 0 END) AS new_in_2nd
+  FROM comments c
+  JOIN comment_jobs cj ON cj.comment_id = c.id
+  JOIN collection_jobs j ON j.id = cj.job_id
+  WHERE j.keyword='이재명-증분검증'
+  GROUP BY c.source;
+"
+```
+
+Expected: 2회차에서 `new_in_2nd`는 네이버/유튜브는 소수(since cutoff 효과), 커뮤니티는 `ON CONFLICT DO NOTHING` 효과로 역시 소수.
+
+- [ ] **Step 6: Stage 0 증분 효과 검증**
+
+진행 상태에서 `articlesSkipped` / `commentsSkipped` 필드가 2회차 수집의 progress JSON에 존재하고 0보다 큰지 확인:
+
+```bash
+psql <dev-dsn> -c "
+  SELECT progress->'item-analysis'
+  FROM collection_jobs
+  WHERE keyword='이재명-증분검증'
+  ORDER BY id DESC
+  LIMIT 2;
+"
+```
+
+Expected: 2회차 job의 `item-analysis` 객체에 `articlesSkipped`, `commentsSkipped` 필드가 포함, 값은 0보다 큼.
+
+- [ ] **Step 7: 분석 재실행으로 Stage 0 통과 시간 측정**
+
+같은 job에 대해 재실행(retry 버튼) 트리거 후 `progress._events` 타임스탬프로 item-analysis 소요 시간 측정:
+
+```bash
+psql <dev-dsn> -c "
+  SELECT progress->'_events'
+  FROM collection_jobs WHERE id=<N>;
+"
+```
+
+Expected: "개별 감정 분석 시작 → 완료" 사이 간격이 5초 이하.
+
+- [ ] **Step 8: 취소 경로 검증**
+
+classify 실행 중 UI에서 취소 버튼 클릭 → DB에서 `collection_jobs.status='cancelled'` 확인, 분석 job은 생성되지 않았는지 `SELECT count(*) FROM collection_jobs WHERE status='running'` 등으로 검증.
+
+- [ ] **Step 9: 결과를 이슈/커밋 메시지로 기록**
+
+```bash
+# 직접 커밋할 게 없으면 결과만 design 문서 §9 수용 기준 체크로 기록
+```
+
+---
+
+## Task 17: 운영 배포 (마이그레이션 + 워커 재시작)
+
+**Files:** 운영 환경
+
+- [ ] **Step 1: main 병합 준비**
+
+Run: `git log --oneline main..HEAD`
+Expected: Task 1~15의 커밋들이 순서대로 나열됨.
+
+- [ ] **Step 2: PR 생성 + 리뷰**
+
+Run:
+
+```bash
+gh pr create --title "수집단계 증분 댓글 수집 + 개별 감정 이동" --body "$(cat <<'EOF'
+## Summary
+- 댓글 증분 수집 (네이버/유튜브 since 하이브리드, 커뮤니티는 firstSeenAt 정책)
+- 개별 감정 분석을 수집 단계(classify 큐 노드)로 이동, 증분 필터 적용
+- 스펙: docs/technical/specs/2026-04-21-수집단계-증분감정-design.md
+
+## Test plan
+- [ ] 개발 DB에서 first_seen_at 보존 확인
+- [ ] 2회차 수집에서 네이버/유튜브 신규 댓글만 증가
+- [ ] 재실행 시 Stage 0 5초 이내 통과
+- [ ] 취소 시 분석 트리거 안 됨
+
+🤖 Generated with Claude Code
+EOF
+)"
+```
+
+- [ ] **Step 3: 운영 DB 마이그레이션**
+
+PR 병합 후 운영 환경에서:
+
+```bash
+pnpm db:push  # 운영 DSN 환경변수로
+# db:migrate-timescale 는 comments 테이블이 하이퍼테이블이 아니면 스킵
+```
+
+Expected: `ALTER TABLE comments ADD COLUMN first_seen_at ...` 성공.
+
+- [ ] **Step 4: 운영 워커 재시작**
+
+Run: `dserver restart ais-collector-worker`
+Expected: 새 코드 기동 로그.
+
+- [ ] **Step 5: 운영 수집 1건 트리거 후 로그 모니터링**
+
+Run: `dserver logs ais-collector-worker --tail=500 -f` 후 UI에서 수집 1건 트리거.
+Expected: classify 노드 정상 실행, 에러 없음.
+
+- [ ] **Step 6: 1주 모니터링**
+
+`progress._events`에서 classify 관련 경고/에러 추적. 이상 발견 시 해당 이슈만 픽스 PR로 처리.
+
+---
+
+## Self-Review
+
+**1. Spec 커버리지 체크:**
+
+- §1.1 댓글 증분 수집 미구현 → Task 5~8, 11~12에서 구현 ✓
+- §1.2 개별 감정 중복 실행 → Task 13~15에서 증분화 + classify 이동 ✓
+- §2 목표 3개 → 전부 Task로 커버 ✓
+- §3.2 classify 노드 → Task 15 ✓
+- §3.3 실패 격리 4개 → Task 15 Step 3에 모두 반영 (BERT 실패, stalled, 취소, 청크 중간 실패는 기존 bulkUpdate 정책 유지) ✓
+- §4.1 firstSeenAt 컬럼 → Task 1 ✓
+- §5 증분 정책 표 → Task 6(네이버), Task 8(유튜브), 커뮤니티 변경 없음 명시 ✓
+- §5.1 RefetchCommentSpec → Task 10 ✓
+- §6 analyzeItems 증분 → Task 14 ✓
+- §6.3 Stage 0 유지 → 코드 변경 없이 증분 덕에 자동 ✓
+- §9 수용 기준 7개 → Task 16에서 수동 검증 ✓
+- §10 롤아웃 → Task 17 ✓
+
+**2. Placeholder 스캔:**
+
+- Task 12 Step 3 YouTube collect 경로의 since 주입 위치는 "파일 확인 후 패턴 적용" 형식인데, 이건 실제 구조가 다를 수 있어 현장 판단이 필요한 지점. 구체 코드 예시는 포함함. 허용 가능.
+- Task 9 Step 2는 DB mocking 패턴 확인 후 둘 중 하나 택일로 제시 — 의사결정 포인트가 명시됨.
+- 나머지 모든 Task에 실제 코드 블록·명령어 포함 ✓
+
+**3. 타입 일관성:**
+
+- `RefetchCommentSpec` (Task 10) → `RefetchCommentSpecVideo` 분리 명시 (articleId vs videoId)
+- `ReusePlanPayload.refetchCommentsFor` (Task 11) → 객체 배열, lastCommentsFetchedAt은 ISO 문자열
+- `CollectionOptions.since` (Task 4) → ISO 문자열 (Zod datetime)
+- `collectForArticle`의 since (Task 6) → Date 객체 (어댑터 내부에서 ISO 문자열 파싱)
+- `options.since` (YouTube, Task 8) → 함수 내부에서 `new Date(options.since)`로 파싱
+
+양쪽 모두 일관: 경계(BullMQ job data, CollectionOptions)는 ISO 문자열, 어댑터 내부는 Date.
+
+**4. 파일 커버리지:**
+
+- File Structure에 등록된 모든 파일이 Task에 등장 ✓

--- a/docs/technical/specs/2026-04-21-수집단계-증분감정-design.md
+++ b/docs/technical/specs/2026-04-21-수집단계-증분감정-design.md
@@ -1,0 +1,324 @@
+# 수집 단계 통합 설계 — 증분 댓글 수집 + 개별 감정 수집 단계 이동
+
+**Date**: 2026-04-21
+**Status**: Draft — 사용자 리뷰 대기
+**Scope**: 스펙 1 (P0 + P2). 스펙 2 (품질 게이트)·스펙 3 (preprocessing 캐시)는 별도 스펙으로 분리.
+
+## 1. 배경
+
+AI SignalCraft 수집 파이프라인은 `수집 → 정규화/persist → 분석 트리거 → (분석 워커: Stage 0 개별감정 → Stage 1~4 LLM)` 흐름으로 동작한다. 현재 코드를 조사한 결과 두 가지 정확성·효율성 문제가 발견되었다.
+
+### 1.1 댓글 증분 수집 미구현
+
+`reuse-planner`는 `article.lastCommentsFetchedAt`의 TTL을 확인해 "댓글만 다시 긁을 대상"을 `refetchCommentsFor: string[]`로 분류한다 (`packages/core/src/pipeline/reuse-planner.ts:103-114`). 하지만 수집 어댑터(`NaverCommentsCollector.collectForArticle` 등)는 `since` 파라미터를 받지 않으므로 **매번 전체 댓글을 처음부터 다시 긁는다**.
+
+- `persistComments`의 `ON CONFLICT DO UPDATE`가 `content / likeCount / dislikeCount`를 덮어쓰기 때문에 "이 댓글이 이번 수집에서 처음 등장했는지 vs 이전부터 있었는지"를 구분할 수 없다 (`packages/core/src/pipeline/persist.ts:156-165`).
+- 네이버 댓글 API는 `sort=FAVORITE`로 호출하고 있어, `commentsPerItem=500` 한도에 걸리면 **인기 댓글만 반복 수집되고 중간 구간 댓글이 영구 누락**될 수 있다.
+
+### 1.2 개별 감정 분석의 중복 실행
+
+`analyzeItems(jobId)`는 현재 분석 워커 Stage 0에서 실행되며, 해당 job에 연결된 **모든** article/comment를 경량 BERT로 재분류한다 (`packages/core/src/analysis/item-analyzer.ts:80-91`). 결과:
+
+- TTL 재사용으로 N:M 조인된 기사는 이미 `sentiment` 컬럼에 값이 있음에도 매 수집마다 재분류된다.
+- 분석 재실행·reportOnly 경로에서도 Stage 0이 매번 돈다 (화면 기준 59초 고정 비용).
+
+## 2. 목표
+
+1. **정확성**: 댓글을 증분으로만 수집하고, 최초 등장 시점을 `first_seen_at`로 영구 보존한다.
+2. **효율성**: 개별 감정 분석을 수집 직후 한 번만 실행하고, 이미 분류된 row는 재실행에서 스킵한다.
+3. **분리**: 개별 감정 분석의 실행 위치를 분석 단계에서 수집 단계로 이동해, "분석 시작" 시점에 항상 sentiment가 채워진 상태를 보장한다.
+
+### Non-goals (이 스펙에서 다루지 않음)
+
+- 수집 직후 품질 게이트 (스펙 2로 분리)
+- preprocessing 결과 영속화·펌글 클러스터링 (스펙 3으로 분리)
+- UI의 "item-analysis / normalization / token-optim..." 대기 박스 표시 정리 (별도 TODO)
+- 원문 스냅샷·DOM 메타 풍부화 (P5, 후속)
+
+## 3. 아키텍처
+
+### 3.1 변경 전 / 변경 후
+
+```
+[변경 전]
+collect-<source>×5 → normalize-<source>×5 → persist
+                                                ├─ persistEmbeddings
+                                                └─ triggerAnalysis ──► analysis 큐
+                                                                         └─ analyzeItems (59s, 전량)
+                                                                         └─ runAnalysisPipeline
+
+[변경 후]
+collect-<source>×5 → normalize-<source>×5 → persist
+                                                ├─ persistEmbeddings
+                                                └─► classify (pipeline 큐 재사용)
+                                                       ├─ analyzeItems (증분, sentiment IS NULL만)
+                                                       └─ triggerAnalysis ──► analysis 큐
+                                                                                └─ runAnalysisPipeline
+                                                                                   (Stage 0은 증분 필터로 즉시 통과)
+```
+
+### 3.2 classify 노드
+
+- **큐**: 기존 `pipeline` 큐 재사용. `job.name === 'classify'`로 분기.
+- **근거**: `@xenova/transformers` ONNX 모델은 프로세스당 1회 로드가 이상적이다. pipeline-worker가 이미 모델을 부르는 경로에 있으므로 별도 워커를 만들지 않는다.
+- **호출 주체**: `persist` 핸들러 말미에서 기존 `triggerAnalysis(dbJobId, keyword)` 호출을 **`triggerClassify(dbJobId, keyword)`로 교체**.
+- **책임**: (1) 증분 item-analysis 실행, (2) 게이트 확인 후 `triggerAnalysis` 호출.
+
+### 3.3 실패 격리
+
+| 실패 지점            | 동작                                                                          |
+| -------------------- | ----------------------------------------------------------------------------- |
+| BERT 모델 로드 실패  | classify 실패 로그 기록, 분석은 sentiment=NULL 상태로 진행                    |
+| 청크 중간 실패       | 완료된 청크까지 DB 저장(기존 bulkUpdate 정책). 재시도 시 `isNull` 필터로 스킵 |
+| classify job stalled | BullMQ 기본 재시도. 증분이므로 멱등                                           |
+| 사용자 취소          | `isPipelineCancelled(dbJobId)` 체크 후 스킵, 분석 트리거도 하지 않음          |
+
+## 4. 스키마 변경
+
+### 4.1 신규 컬럼 1개
+
+```typescript
+// packages/core/src/db/schema/collections.ts — comments 테이블
+firstSeenAt: timestamp('first_seen_at').defaultNow().notNull(),
+```
+
+- `persistComments`의 `onConflictDoUpdate.set`에 `firstSeenAt`을 **포함하지 않는다** → 최초 저장 시점이 영구 보존된다.
+- 기존 row는 마이그레이션 시 `DEFAULT now()`로 "마이그레이션 시점에 처음 봄"으로 처리된다 (수용 가능한 근사, backfill 불필요).
+- 운영 반영: `pnpm db:push`. TimescaleDB UNIQUE 제약은 별도 스크립트 관리 원칙 유지 (MEMORY 참고).
+
+### 4.2 기존 컬럼 재사용
+
+- `articles.sentiment / sentiment_score`, `comments.sentiment / sentiment_score` — 이미 존재 (`packages/core/src/db/schema/collections.ts:193-194`).
+- `articles.lastCommentsFetchedAt / lastFetchedAt` — 이미 존재, 정책 그대로 유지.
+
+## 5. 댓글 증분 수집 정책 (하이브리드)
+
+| 소스             | since 기준             | 조기 종료 조건                                                           | 어댑터 변경                                                                             |
+| ---------------- | ---------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| 네이버 뉴스 댓글 | `publishedAt`          | `publishedAt < since`가 연속 20개 나타나면 stop                          | `collectForArticle(url, { maxComments, since?, sort? })`. since 모드에서는 `sort='NEW'` |
+| 유튜브 댓글      | `publishedAt`          | 최신순(`order=time`)으로 받다가 `publishedAt < since`면 stop             | `collectForVideo(videoId, { maxComments, since?, commentOrder? })`                      |
+| DC갤러리         | `first_seen_at` (간접) | `knownSourceIds`에 포함되지 않은 신규 댓글이 **N페이지 연속 0개**면 stop | `CommunityBaseCollector` 옵션 `knownSourceIds?: Set<string>` 추가                       |
+| fmkorea          | 동일                   | 동일                                                                     | 동일                                                                                    |
+| clien            | 동일                   | 동일                                                                     | 동일                                                                                    |
+
+**하이브리드 근거**:
+
+- 네이버/유튜브는 원문의 시간 정보가 정확하다 → `publishedAt` 기준이 시계열 분석(delta 모듈)에 정합.
+- 커뮤니티는 상대시간("3시간 전")이 많고 파싱이 불안정하다 → DB의 기존 `sourceId` 집합을 어댑터에 주입해 "이미 본 것"을 기준으로 삼는다.
+
+### 5.1 since 전달 경로
+
+- `reuse-planner`가 이미 select하고 있는 `lastCommentsFetchedAt`을 URL별로 함께 전달하도록 타입 확장:
+
+```typescript
+// packages/core/src/pipeline/reuse-planner.ts
+export interface RefetchCommentSpec {
+  url: string;
+  articleId: number;
+  lastCommentsFetchedAt: Date | null; // null이면 전량 (fallback)
+}
+
+export interface ArticleReusePlan {
+  reuseArticleIds: number[];
+  skipUrls: string[];
+  refetchCommentsFor: RefetchCommentSpec[]; // string[] → RefetchCommentSpec[]
+  evaluated: number;
+}
+```
+
+- `flows.ts`가 `RefetchCommentSpec[]`을 pipeline-worker에 전달한다.
+- pipeline-worker의 네이버 댓글 수집부(`collectArticleComments`)는 `detail`과 함께 해당 기사의 `lastCommentsFetchedAt`을 `since`로 collector에 넘긴다.
+
+### 5.2 커뮤니티 소스의 `knownSourceIds` 주입
+
+- 재사용 대상 기사의 기존 댓글 sourceId를 pre-load:
+
+  ```sql
+  SELECT source_id FROM comments
+  WHERE article_id = ANY($1::int[]) AND source = $2
+  ```
+
+- 결과를 `Set<string>`으로 담아 어댑터 옵션으로 주입. 수백~수천 row 수준이라 메모리 부담 없음.
+
+### 5.3 엣지 케이스
+
+| 케이스                             | 처리                                                                |
+| ---------------------------------- | ------------------------------------------------------------------- |
+| since 이후 댓글이 maxComments 초과 | 최신순으로 자르고 경고 이벤트. `commentsPerItem`은 "이번 수집 한도" |
+| since가 reuse TTL보다 과거         | reuse-planner가 애초에 reuse 대상으로 분류하지 않음 → 전량 재수집   |
+| 댓글 0건 확인                      | `lastCommentsFetchedAt`은 갱신 (기존 정책 유지)                     |
+| forceRefetch=true                  | since 무시, 전량 재수집 (기존 동작 유지)                            |
+| since가 null (첫 수집)             | 전량 수집 (기존 동작 유지)                                          |
+
+### 5.4 변경되지 않는 것
+
+- `persistComments`의 `ON CONFLICT DO UPDATE` — content/likeCount 업데이트는 의도된 동작 (댓글 수정 반영).
+- `commentJobs` N:M 조인 — 같은 댓글이 여러 job에 연결.
+- `persistComments` 말미의 `lastCommentsFetchedAt` 갱신.
+
+## 6. 개별 감정 분석 증분화
+
+### 6.1 `analyzeItems` 쿼리 변경
+
+```typescript
+// packages/core/src/analysis/item-analyzer.ts
+import { and, isNull } from 'drizzle-orm';
+
+const [articleRows, commentRows] = await Promise.all([
+  db
+    .select({ id: articles.id, title: articles.title, content: articles.content })
+    .from(articles)
+    .innerJoin(articleJobs, eq(articles.id, articleJobs.articleId))
+    .where(and(eq(articleJobs.jobId, jobId), isNull(articles.sentiment))),
+  db
+    .select({ id: comments.id, content: comments.content })
+    .from(comments)
+    .innerJoin(commentJobs, eq(comments.id, commentJobs.commentId))
+    .where(and(eq(commentJobs.jobId, jobId), isNull(comments.sentiment))),
+]);
+```
+
+### 6.2 progress UI 카운트 정책
+
+신규 필드 2개 추가:
+
+```typescript
+'item-analysis': {
+  status, phase,
+  articlesTotal,        // jobId 연결 전체 (기존)
+  articlesAnalyzed,     // 이번에 분류 (기존)
+  articlesSkipped,      // 이미 sentiment 있어 재분류 안 한 수 (신규)
+  commentsTotal,
+  commentsAnalyzed,
+  commentsSkipped,
+}
+```
+
+`articlesTotal`은 여전히 전체 수. `articlesAnalyzed + articlesSkipped = articlesTotal`.
+
+UI 표기 예: `"4160 / 4160 (재사용 2108건)"`.
+
+### 6.3 Stage 0에서의 호출은 제거하지 않음
+
+- `runAnalysisPipeline` Stage 0의 `analyzeItems(jobId)` 호출 (`packages/core/src/analysis/pipeline-orchestrator.ts:214`)을 **유지**한다.
+- 이유: 분석 재실행/reportOnly 경로에서도 동일 invariant("sentiment 채워졌는가")가 보장되어야 한다.
+- 증분 필터 덕에 재실행 시 "0건 분류, 즉시 통과"로 동작 (1~2초).
+- Single source of truth는 DB의 `sentiment` 컬럼. classify 노드는 수집-분석 경계에서의 선행 실행 최적화.
+
+## 7. flow 및 체인 변경
+
+### 7.1 flows.ts 신규 헬퍼
+
+```typescript
+// packages/core/src/queue/flows.ts
+export async function triggerClassify(dbJobId: number, keyword: string) {
+  const flow = await getFlowProducer().add({
+    name: 'classify',
+    queueName: 'pipeline',
+    data: { dbJobId, keyword },
+    opts: {
+      removeOnComplete: { age: 3600 },
+      removeOnFail: { age: 86400 },
+    },
+  });
+  return flow;
+}
+```
+
+### 7.2 pipeline-worker.ts 변경점
+
+(a) `persist` 핸들러 말미:
+
+```typescript
+// 기존
+await triggerAnalysis(dbJobId, keyword);
+
+// 변경
+await triggerClassify(dbJobId, keyword);
+```
+
+(b) 신규 분기:
+
+```typescript
+if (job.name === 'classify') {
+  const { dbJobId, keyword } = job.data;
+  if (await isPipelineCancelled(dbJobId)) return { skipped: true, reason: 'cancelled' };
+
+  try {
+    await analyzeItems(dbJobId);
+  } catch (err) {
+    logger.warn(`[classify] item-analysis 실패, 분석 계속:`, err);
+    await appendJobEvent(
+      dbJobId,
+      'warn',
+      `개별 감정 분석 실패 (분석은 계속 진행됨): ${err instanceof Error ? err.message : String(err)}`,
+    ).catch(() => void 0);
+  }
+
+  if (!(await awaitStageGate(dbJobId, 'normalize'))) {
+    return { cancelled: true };
+  }
+  await triggerAnalysis(dbJobId, keyword);
+  return { classified: true };
+}
+```
+
+## 8. 변경 파일 목록
+
+### 8.1 Core / Pipeline
+
+- `packages/core/src/db/schema/collections.ts` — `comments.firstSeenAt` 추가
+- `packages/core/src/pipeline/reuse-planner.ts` — `RefetchCommentSpec` 타입 추가, `refetchCommentsFor` 타입 확장
+- `packages/core/src/pipeline/persist.ts` — `firstSeenAt`이 `onConflictDoUpdate.set`에 포함되지 않음을 명시적으로 확인
+- `packages/core/src/queue/flows.ts` — `triggerClassify` 추가, `RefetchCommentSpec` 전달 경로
+- `packages/core/src/queue/pipeline-worker.ts` — `classify` 분기, 댓글 수집부의 `since` / `knownSourceIds` 주입
+- `packages/core/src/analysis/item-analyzer.ts` — `isNull(sentiment)` 필터, `skipped` 카운트
+
+### 8.2 Collectors
+
+- `packages/collectors/src/adapters/naver-comments.ts` — `collectForArticle(url, { maxComments, since?, sort? })`, since 모드에서 `sort='NEW'` 및 연속 20개 cutoff
+- `packages/collectors/src/adapters/youtube-comments.ts` — `collectForVideo(id, { maxComments, since?, commentOrder? })`, `order=time` + publishedAt cutoff
+- `packages/collectors/src/adapters/community-base-collector.ts` — `knownSourceIds?: Set<string>` 옵션, "신규 sourceId가 N페이지 연속 0개면 stop" 정책
+
+### 8.3 UI (선택적, 별도 PR로 분리 가능)
+
+- `apps/web/src/components/analysis/pipeline-monitor/timeline-bar.tsx` 및 관련 stage 렌더링 지점 — `articlesSkipped / commentsSkipped` 표시 추가
+- `apps/web/src/server/pipeline-status/index.ts` — progress JSON에 신규 필드 통과
+
+### 8.4 테스트
+
+- `packages/core/src/analysis/__tests__/item-analyzer.incremental.test.ts` — sentiment 있는 row 스킵, skipped 카운트 정확성
+- `packages/core/src/pipeline/__tests__/reuse-planner.refetch.test.ts` — `RefetchCommentSpec` 반환 구조
+- `packages/collectors/src/adapters/__tests__/naver-comments.incremental.test.ts` — since 기반 조기 종료
+- `packages/collectors/src/adapters/__tests__/community-base.known-source.test.ts` — knownSourceIds 기반 조기 종료
+
+## 9. 수용 기준 (Acceptance Criteria)
+
+1. **댓글 증분**: 같은 기사를 2회 연속 수집할 때, 2회차에서 새로 저장되는 댓글은 "2회차 수집 시점 이후 publishedAt" 또는 "sourceId가 1회차에 없던" 것만이어야 한다.
+2. **first_seen_at 보존**: `persistComments`의 upsert가 기존 row의 `first_seen_at`을 변경하지 않는다.
+3. **개별 감정 증분**: TTL 재사용된 기사·댓글은 `analyzeItems`에서 BERT 호출을 받지 않으며, `articlesSkipped + articlesAnalyzed = articlesTotal`이 성립한다.
+4. **분석 큐 호출 시점**: classify 노드가 성공하든 BERT 실패하든 `triggerAnalysis`는 호출된다 (취소된 경우 제외).
+5. **재실행 통과 시간**: 모든 row의 sentiment가 이미 채워진 상태에서 분석 재실행 시, Stage 0 소요 시간이 수집 직후 대비 90% 이상 단축 (즉 ~5초 이하).
+6. **forceRefetch 호환**: `forceRefetch=true`면 since 무시, 전량 재수집 동작이 유지된다.
+7. **취소 중 안전성**: classify 노드 실행 중 취소 시, 이미 분류된 청크는 DB에 남고 `triggerAnalysis`는 호출되지 않는다.
+
+## 10. 롤아웃
+
+1. 스키마 마이그레이션(`pnpm db:push`) — 운영 DB에 `first_seen_at` 추가. 기존 row는 `now()`로 채워짐.
+2. 코드 배포 (collectors → core → web 순, 의존성 방향 기준).
+3. 1주일간 `collection_jobs.progress._events`에서 `firstSeenAt` 관련 경고 모니터링.
+4. 이상 없으면 스펙 2 (품질 게이트) 설계 진입.
+
+## 11. 리스크와 완화
+
+| 리스크                                         | 완화                                                                                                                  |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| 네이버 댓글 `sort='NEW'` 전환이 모수 편향 유발 | since 모드에서만 NEW. since=null이면 기존 FAVORITE 유지                                                               |
+| 커뮤니티 "연속 0개" cutoff가 너무 공격적       | 페이지 수 threshold를 env 변수로 외부화, 초기값은 보수적(3페이지)                                                     |
+| Stage 0 증분 쿼리가 인덱스 미스                | `articles(sentiment)` / `comments(sentiment)` 부분 인덱스 필요 여부는 운영 관찰 후 판단 (P95 쿼리 100ms 초과 시 추가) |
+| classify 노드 중복 실행                        | BullMQ job id 유니크 보장. 증분 필터로 멱등                                                                           |
+
+## 12. 후속 스펙과의 연결
+
+- **스펙 2 (품질 게이트)**: classify 완료 시점에 `sentiment` 집계가 확보되므로 편향 지표(`sentimentSkew`)를 바로 계산 가능. classify 다음에 `quality-gate` 노드를 삽입하는 구조 고려.
+- **스펙 3 (preprocessing 캐시)**: `sentiment` 값이 안정되면 preprocessing 입력 해시 키에 sentiment를 포함해 캐시 무효화 방지 가능.

--- a/docs/technical/specs/2026-04-21-수집단계-증분감정-design.md
+++ b/docs/technical/specs/2026-04-21-수집단계-증분감정-design.md
@@ -93,18 +93,24 @@ firstSeenAt: timestamp('first_seen_at').defaultNow().notNull(),
 
 ## 5. 댓글 증분 수집 정책 (하이브리드)
 
-| 소스             | since 기준             | 조기 종료 조건                                                           | 어댑터 변경                                                                             |
-| ---------------- | ---------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| 네이버 뉴스 댓글 | `publishedAt`          | `publishedAt < since`가 연속 20개 나타나면 stop                          | `collectForArticle(url, { maxComments, since?, sort? })`. since 모드에서는 `sort='NEW'` |
-| 유튜브 댓글      | `publishedAt`          | 최신순(`order=time`)으로 받다가 `publishedAt < since`면 stop             | `collectForVideo(videoId, { maxComments, since?, commentOrder? })`                      |
-| DC갤러리         | `first_seen_at` (간접) | `knownSourceIds`에 포함되지 않은 신규 댓글이 **N페이지 연속 0개**면 stop | `CommunityBaseCollector` 옵션 `knownSourceIds?: Set<string>` 추가                       |
-| fmkorea          | 동일                   | 동일                                                                     | 동일                                                                                    |
-| clien            | 동일                   | 동일                                                                     | 동일                                                                                    |
+| 소스             | since 기준         | 조기 종료 조건                                               | 어댑터 변경                                                                             |
+| ---------------- | ------------------ | ------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| 네이버 뉴스 댓글 | `publishedAt`      | `publishedAt < since`가 연속 20개 나타나면 stop              | `collectForArticle(url, { maxComments, since?, sort? })`. since 모드에서는 `sort='NEW'` |
+| 유튜브 댓글      | `publishedAt`      | 최신순(`order=time`)으로 받다가 `publishedAt < since`면 stop | `collectForVideo(videoId, { maxComments, since?, commentOrder? })`                      |
+| DC갤러리         | (어댑터 변경 없음) | persist 단계의 `ON CONFLICT DO NOTHING`에 의존               | 변경 없음                                                                               |
+| fmkorea          | 동일               | 동일                                                         | 동일                                                                                    |
+| clien            | 동일               | 동일                                                         | 동일                                                                                    |
 
-**하이브리드 근거**:
+**커뮤니티 예외 근거** (spec 재검토 결과 반영):
 
-- 네이버/유튜브는 원문의 시간 정보가 정확하다 → `publishedAt` 기준이 시계열 분석(delta 모듈)에 정합.
-- 커뮤니티는 상대시간("3시간 전")이 많고 파싱이 불안정하다 → DB의 기존 `sourceId` 집합을 어댑터에 주입해 "이미 본 것"을 기준으로 삼는다.
+- 커뮤니티 어댑터는 `fetchPost`에서 **게시글 HTML 전체를 한 번에 파싱**해 댓글을 추출한다. 댓글만 따로 가져오는 엔드포인트가 없으므로 "댓글 조기 종료" 이득이 작다.
+- `persistComments`의 `onConflictDoNothing`과 새로 추가될 `firstSeenAt DEFAULT now()`만으로 최초 등장 시점 보존 + 중복 저장 방지가 충분히 달성된다.
+- 이 스펙의 목표(정확성 + 수집 단계 감정 이동)는 스키마 변경만으로 커뮤니티에 대해서도 달성되므로, 어댑터 시그니처 확장은 **YAGNI 원칙에 따라 이번 스펙에서 제외**.
+
+**하이브리드 근거 (네이버/유튜브)**:
+
+- 원문의 시간 정보가 정확하다 → `publishedAt` 기준이 시계열 분석(delta 모듈)에 정합.
+- `sort=NEW` / `order=time`으로 최신 N개만 받고 조기 종료 → **인기 댓글 편향으로 인한 "중간 구간 영구 누락" 버그(섹션 1.1)를 근본 해소**.
 
 ### 5.1 since 전달 경로
 
@@ -129,16 +135,10 @@ export interface ArticleReusePlan {
 - `flows.ts`가 `RefetchCommentSpec[]`을 pipeline-worker에 전달한다.
 - pipeline-worker의 네이버 댓글 수집부(`collectArticleComments`)는 `detail`과 함께 해당 기사의 `lastCommentsFetchedAt`을 `since`로 collector에 넘긴다.
 
-### 5.2 커뮤니티 소스의 `knownSourceIds` 주입
+### 5.2 커뮤니티 소스 처리 (어댑터 변경 없음)
 
-- 재사용 대상 기사의 기존 댓글 sourceId를 pre-load:
-
-  ```sql
-  SELECT source_id FROM comments
-  WHERE article_id = ANY($1::int[]) AND source = $2
-  ```
-
-- 결과를 `Set<string>`으로 담아 어댑터 옵션으로 주입. 수백~수천 row 수준이라 메모리 부담 없음.
+- 이번 스펙에서 어댑터 증분은 네이버/유튜브에만 적용한다. 근거는 위 표의 "커뮤니티 예외 근거" 참고.
+- `persistComments`의 `firstSeenAt` 정책 + N:M 조인으로 최초 등장 시점 보존과 중복 방지는 모두 달성됨.
 
 ### 5.3 엣지 케이스
 
@@ -155,6 +155,7 @@ export interface ArticleReusePlan {
 - `persistComments`의 `ON CONFLICT DO UPDATE` — content/likeCount 업데이트는 의도된 동작 (댓글 수정 반영).
 - `commentJobs` N:M 조인 — 같은 댓글이 여러 job에 연결.
 - `persistComments` 말미의 `lastCommentsFetchedAt` 갱신.
+- 커뮤니티 어댑터 3종(dcinside/fmkorea/clien) 및 `CommunityBaseCollector`.
 
 ## 6. 개별 감정 분석 증분화
 
@@ -277,8 +278,8 @@ if (job.name === 'classify') {
 ### 8.2 Collectors
 
 - `packages/collectors/src/adapters/naver-comments.ts` — `collectForArticle(url, { maxComments, since?, sort? })`, since 모드에서 `sort='NEW'` 및 연속 20개 cutoff
-- `packages/collectors/src/adapters/youtube-comments.ts` — `collectForVideo(id, { maxComments, since?, commentOrder? })`, `order=time` + publishedAt cutoff
-- `packages/collectors/src/adapters/community-base-collector.ts` — `knownSourceIds?: Set<string>` 옵션, "신규 sourceId가 N페이지 연속 0개면 stop" 정책
+- `packages/collectors/src/adapters/youtube-comments.ts` — `collect(options)`의 `CollectionOptions`에 `since` 지원 추가, `order='time'` 전환 + publishedAt cutoff
+- 커뮤니티 어댑터 3종: 변경 없음 (spec §5.1~§5.2 근거)
 
 ### 8.3 UI (선택적, 별도 PR로 분리 가능)
 

--- a/packages/collectors/src/adapters/base.ts
+++ b/packages/collectors/src/adapters/base.ts
@@ -27,6 +27,9 @@ export const CollectionOptionsSchema = z.object({
       refetchCommentsFor: z.array(z.string()).default([]),
     })
     .optional(),
+  // 증분 댓글 수집 컷오프. 이 시각 이후(publishedAt > since)의 댓글만 수집.
+  // 네이버/유튜브 댓글 어댑터만 해석한다 (커뮤니티 어댑터는 무시).
+  since: z.string().datetime().optional(),
   commentOrder: z.enum(['relevance', 'time']).default('relevance').optional(),
   collectTranscript: z.boolean().default(true).optional(),
 });

--- a/packages/collectors/src/adapters/base.ts
+++ b/packages/collectors/src/adapters/base.ts
@@ -24,7 +24,16 @@ export const CollectionOptionsSchema = z.object({
   reusePlan: z
     .object({
       skipUrls: z.array(z.string()).default([]),
-      refetchCommentsFor: z.array(z.string()).default([]),
+      refetchCommentsFor: z
+        .array(
+          z.object({
+            url: z.string(),
+            articleId: z.number().int().optional(),
+            videoId: z.number().int().optional(),
+            lastCommentsFetchedAt: z.string().datetime().nullable(),
+          }),
+        )
+        .default([]),
     })
     .optional(),
   // 증분 댓글 수집 컷오프. 이 시각 이후(publishedAt > since)의 댓글만 수집.

--- a/packages/collectors/src/adapters/community-base-collector.ts
+++ b/packages/collectors/src/adapters/community-base-collector.ts
@@ -90,7 +90,9 @@ export abstract class CommunityBaseCollector extends BrowserCollector<CommunityP
 
     // TTL 재사용: 완전 스킵 URL 집합과 댓글-only URL 집합 (Set 으로 O(1) 조회)
     const skipUrlSet = new Set(options.reusePlan?.skipUrls ?? []);
-    const refetchCommentsOnlySet = new Set(options.reusePlan?.refetchCommentsFor ?? []);
+    const refetchCommentsOnlySet = new Set(
+      (options.reusePlan?.refetchCommentsFor ?? []).map((s) => s.url),
+    );
 
     // 기간 필터: KST 자정 기준 [startDay, endDay + 24h)로 확장.
     // 사용자가 "KST 04-11 ~ KST 04-18"을 입력하면 04-11 00:00 KST ~ 04-19 00:00 KST 가 기간.

--- a/packages/collectors/src/adapters/naver-comments.ts
+++ b/packages/collectors/src/adapters/naver-comments.ts
@@ -76,10 +76,19 @@ export class NaverCommentsCollector implements Collector<NaverComment> {
   /**
    * 특정 기사의 댓글 수집
    * 실제 파이프라인에서 사용하는 메서드
+   *
+   * since 증분 모드:
+   * - since 지정 시 sort를 'NEW'로 전환해 최신순으로 받는다.
+   * - publishedAt <= since 인 댓글이 연속 OLD_CONSECUTIVE_CUTOFF(20)개 나오면 조기 종료.
+   * - 결과에는 since 이후 댓글만 포함된다.
    */
   async *collectForArticle(
     articleUrl: string,
-    options?: { maxComments?: number },
+    options?: {
+      maxComments?: number;
+      since?: Date;
+      sort?: 'FAVORITE' | 'NEW';
+    },
   ): AsyncGenerator<NaverComment[], void, unknown> {
     const parsed = parseNaverArticleUrl(articleUrl);
     if (!parsed) {
@@ -90,8 +99,14 @@ export class NaverCommentsCollector implements Collector<NaverComment> {
     const objectId = buildObjectId(oid, aid);
     const articleSourceId = `${oid}_${aid}`;
     const maxComments = options?.maxComments ?? DEFAULT_MAX_COMMENTS;
+    const since = options?.since ?? null;
+    // since 있으면 최신순(NEW), 없으면 기존 FAVORITE 유지
+    const sort: 'FAVORITE' | 'NEW' = options?.sort ?? (since ? 'NEW' : 'FAVORITE');
+    const OLD_CONSECUTIVE_CUTOFF = 20;
+
     let totalCollected = 0;
     let currentPage = 1;
+    let consecutiveOld = 0;
 
     // Referer 헤더 -- 기사 댓글 페이지 URL (필수, 없으면 403)
     const referer = `https://n.news.naver.com/article/comment/${oid}/${aid}`;
@@ -101,7 +116,7 @@ export class NaverCommentsCollector implements Collector<NaverComment> {
         objectId,
         page: currentPage,
         pageSize: 100,
-        sort: 'FAVORITE',
+        sort,
       });
 
       const response = await fetch(apiUrl, {
@@ -131,8 +146,29 @@ export class NaverCommentsCollector implements Collector<NaverComment> {
       if (!commentList || commentList.length === 0) break;
 
       const comments: NaverComment[] = [];
+      let stopAfterPage = false; // since cutoff 또는 maxComments 도달 시 yield 후 pageLoop 종료용
       for (const raw of commentList) {
-        if (totalCollected >= maxComments) break;
+        if (totalCollected >= maxComments) {
+          stopAfterPage = true;
+          break;
+        }
+
+        const publishedAt: Date | null = raw.modTime
+          ? new Date(String(raw.modTime))
+          : raw.regTime
+            ? new Date(String(raw.regTime))
+            : null;
+
+        // since 컷오프: publishedAt <= since 이면 "오래된 것"으로 카운트하고 건너뜀
+        if (since && publishedAt && publishedAt.getTime() <= since.getTime()) {
+          consecutiveOld++;
+          if (consecutiveOld >= OLD_CONSECUTIVE_CUTOFF) {
+            stopAfterPage = true;
+            break;
+          }
+          continue;
+        }
+        consecutiveOld = 0;
 
         comments.push({
           sourceId: String(raw.commentNo ?? raw.ticket ?? ''),
@@ -142,20 +178,19 @@ export class NaverCommentsCollector implements Collector<NaverComment> {
           author: String(raw.maskedUserId ?? raw.userName ?? '익명'),
           likeCount: Number(raw.sympathyCount ?? 0),
           dislikeCount: Number(raw.antipathyCount ?? 0),
-          publishedAt: raw.modTime
-            ? new Date(String(raw.modTime))
-            : raw.regTime
-              ? new Date(String(raw.regTime))
-              : null,
+          publishedAt,
           rawData: raw,
         });
 
         totalCollected++;
       }
 
+      // stopAfterPage 여부와 무관하게, 이번 페이지에서 수집된 comments는 먼저 yield
       if (comments.length > 0) {
         yield comments;
       }
+
+      if (stopAfterPage) break;
 
       // 전체 페이지 확인
       const pageModel = result.pageModel as Record<string, unknown> | undefined;

--- a/packages/collectors/src/adapters/naver-comments.ts
+++ b/packages/collectors/src/adapters/naver-comments.ts
@@ -159,7 +159,10 @@ export class NaverCommentsCollector implements Collector<NaverComment> {
             ? new Date(String(raw.regTime))
             : null;
 
-        // since 컷오프: publishedAt <= since 이면 "오래된 것"으로 카운트하고 건너뜀
+        // since 컷오프: publishedAt <= since 이면 "오래된 것"으로 카운트하고 건너뜀.
+        // publishedAt이 null이면 cutoff 판단 불가 → 보수적으로 포함 + consecutiveOld 미증가.
+        // (네이버 API에서 날짜 누락은 극히 드물지만, 연속 null이 와도 cutoff가 도달 못하는
+        //  최악의 경우에도 maxComments가 상한 역할을 한다)
         if (since && publishedAt && publishedAt.getTime() <= since.getTime()) {
           consecutiveOld++;
           if (consecutiveOld >= OLD_CONSECUTIVE_CUTOFF) {

--- a/packages/collectors/src/adapters/naver-news.ts
+++ b/packages/collectors/src/adapters/naver-news.ts
@@ -161,7 +161,9 @@ export class NaverNewsCollector implements Collector<NaverArticle> {
     // TTL 재사용: 완전 스킵 URL 은 Phase 2 본문 수집에서 제외
     // 재사용 기사는 flows.ts 에서 article_jobs 로 이미 연결됨 → 분석 단계에서 자동 포함
     const skipUrlSet = new Set(options.reusePlan?.skipUrls ?? []);
-    const refetchCommentsOnlySet = new Set(options.reusePlan?.refetchCommentsFor ?? []);
+    const refetchCommentsOnlySet = new Set(
+      (options.reusePlan?.refetchCommentsFor ?? []).map((s) => s.url),
+    );
     const preSkipCount = allArticles.length;
     const filteredArticles = allArticles.filter((a) => !skipUrlSet.has(a.url));
     const skippedByReuse = preSkipCount - filteredArticles.length;

--- a/packages/collectors/src/adapters/youtube-collector.ts
+++ b/packages/collectors/src/adapters/youtube-collector.ts
@@ -38,7 +38,7 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
     const days = splitIntoDaysKst(options.startDate, options.endDate);
     const perDayLimit = options.maxItemsPerDay ?? Math.max(1, Math.floor(maxItems / days.length));
     const skipUrlSet = new Set(options.reusePlan?.skipUrls ?? []);
-    const refetchSet = new Set(options.reusePlan?.refetchCommentsFor ?? []);
+    const refetchSet = new Set((options.reusePlan?.refetchCommentsFor ?? []).map((s) => s.url));
     const perDayCount: Record<string, number> = {};
     let totalCollected = 0;
     let endReason: CollectionStats['endReason'] = 'completed';

--- a/packages/collectors/src/adapters/youtube-collector.ts
+++ b/packages/collectors/src/adapters/youtube-collector.ts
@@ -38,7 +38,12 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
     const days = splitIntoDaysKst(options.startDate, options.endDate);
     const perDayLimit = options.maxItemsPerDay ?? Math.max(1, Math.floor(maxItems / days.length));
     const skipUrlSet = new Set(options.reusePlan?.skipUrls ?? []);
-    const refetchSet = new Set((options.reusePlan?.refetchCommentsFor ?? []).map((s) => s.url));
+    // 댓글 재수집 대상 URL + since 맵
+    const refetchSpecs = options.reusePlan?.refetchCommentsFor ?? [];
+    const refetchUrlToSince = new Map<string, string | null>(
+      refetchSpecs.map((s) => [s.url, s.lastCommentsFetchedAt]),
+    );
+    const refetchSet = new Set(refetchSpecs.map((s) => s.url));
     const perDayCount: Record<string, number> = {};
     let totalCollected = 0;
     let endReason: CollectionStats['endReason'] = 'completed';
@@ -46,9 +51,14 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
     let perDayCapSkip = 0;
     let outOfRange = 0;
 
-    // 댓글 재수집 대상이 있으면 먼저 처리
+    // 댓글 재수집 대상이 있으면 먼저 처리 (since 기반 증분)
     if (refetchSet.size > 0) {
-      yield* this.refetchCommentsOnly([...refetchSet], maxComments, commentOrder);
+      yield* this.refetchCommentsOnly(
+        [...refetchSet],
+        maxComments,
+        commentOrder,
+        refetchUrlToSince,
+      );
     }
 
     for (const day of days) {
@@ -259,21 +269,28 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
     videoId: string,
     max: number,
     order: 'relevance' | 'time',
+    sinceIso?: string | null,
   ): Promise<YoutubeComment[]> {
     if (this.shouldUseFallback()) {
+      // Innertube 경로는 since 미지원 (fallback 용도)
       return this.collectCommentsViaInnertube(videoId, max);
     }
-    return this.collectCommentsViaApi(videoId, max, order);
+    // since 지정 시 order='time' 강제 (최신순 필수)
+    const effectiveOrder: 'relevance' | 'time' = sinceIso ? 'time' : order;
+    return this.collectCommentsViaApi(videoId, max, effectiveOrder, sinceIso ?? null);
   }
 
   private async collectCommentsViaApi(
     videoId: string,
     max: number,
     order: 'relevance' | 'time',
+    sinceIso: string | null = null,
   ): Promise<YoutubeComment[]> {
     const youtube = getYoutubeClient();
     const comments: YoutubeComment[] = [];
+    const sinceMs = sinceIso ? new Date(sinceIso).getTime() : null;
     let pageToken: string | undefined;
+    let stopDueToSince = false;
 
     while (comments.length < max) {
       try {
@@ -292,6 +309,15 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
         for (const thread of items) {
           const top = thread.snippet?.topLevelComment;
           if (top?.snippet) {
+            // since cutoff: 최신순 정렬이므로 첫 오래된 것 발견 시 즉시 종료
+            const publishedAtIso = top.snippet.publishedAt;
+            if (sinceMs !== null && publishedAtIso) {
+              const ts = new Date(publishedAtIso).getTime();
+              if (ts <= sinceMs) {
+                stopDueToSince = true;
+                break;
+              }
+            }
             comments.push(this.mapApiComment(top, null, videoId));
           }
           // 대댓글: API가 최대 5개만 반환 → totalReplyCount > 5이면 추가 호출
@@ -310,6 +336,8 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
             }
           }
         }
+
+        if (stopDueToSince) break;
 
         pageToken = res.data.nextPageToken ?? undefined;
         if (!pageToken) break;
@@ -400,11 +428,14 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
     urls: string[],
     max: number,
     order: 'relevance' | 'time',
+    urlToSince?: Map<string, string | null>,
   ): AsyncGenerator<YoutubeVideo[], void, unknown> {
     for (const url of urls) {
       const videoId = extractVideoId(url);
       if (!videoId) continue;
-      const comments = await this.collectComments(videoId, max, order);
+      // since 지정 시 collectComments는 order=time 강제 + publishedAt 컷오프
+      const since = urlToSince?.get(url) ?? undefined;
+      const comments = await this.collectComments(videoId, max, order, since ?? undefined);
       yield [
         {
           sourceId: videoId,

--- a/packages/collectors/src/adapters/youtube-comments.ts
+++ b/packages/collectors/src/adapters/youtube-comments.ts
@@ -41,10 +41,19 @@ export class YoutubeCommentsCollector implements Collector<YoutubeComment> {
    * keyword에 videoId를 전달
    * 페이지 단위(최대 100건)로 yield
    */
+  /**
+   * since 증분 모드:
+   * - options.since 지정 시 order='time'으로 강제 (최신순 필수).
+   * - 최신순 정렬 상태에서 publishedAt <= since 댓글 발견 시 즉시 종료
+   *   (같은 페이지 내 이후 댓글과 다음 페이지는 모두 더 오래됨).
+   */
   async *collect(options: CollectionOptions): AsyncGenerator<YoutubeComment[], void, unknown> {
     const youtube = getYoutubeClient();
-    const videoId = options.keyword; // videoId를 keyword로 전달
+    const videoId = options.keyword;
     const maxComments = options.maxComments ?? DEFAULT_MAX_COMMENTS;
+    const since = options.since ? new Date(options.since) : null;
+    const order: 'time' | 'relevance' = since ? 'time' : (options.commentOrder ?? 'relevance');
+
     let totalCollected = 0;
     let nextPageToken: string | undefined;
 
@@ -54,7 +63,7 @@ export class YoutubeCommentsCollector implements Collector<YoutubeComment> {
           part: ['snippet', 'replies'],
           videoId,
           maxResults: Math.min(maxComments - totalCollected, COMMENTS_PAGE_SIZE),
-          order: 'relevance',
+          order,
           pageToken: nextPageToken,
         });
 
@@ -62,37 +71,51 @@ export class YoutubeCommentsCollector implements Collector<YoutubeComment> {
         if (!items || items.length === 0) break;
 
         const comments: YoutubeComment[] = [];
+        let stopAfterPage = false;
 
         for (const thread of items) {
-          // 최상위 댓글
           const topComment = thread.snippet?.topLevelComment;
-          if (topComment?.snippet) {
-            comments.push({
-              sourceId: topComment.id ?? '',
-              parentId: null,
-              videoSourceId: videoId,
-              content: topComment.snippet.textDisplay ?? '',
-              author: topComment.snippet.authorDisplayName ?? '',
-              likeCount: topComment.snippet.likeCount ?? 0,
-              publishedAt: topComment.snippet.publishedAt
-                ? new Date(topComment.snippet.publishedAt)
-                : null,
-              rawData: topComment as unknown as Record<string, unknown>,
-            });
+          if (!topComment?.snippet) continue;
+
+          const publishedAt: Date | null = topComment.snippet.publishedAt
+            ? new Date(topComment.snippet.publishedAt)
+            : null;
+
+          // since cutoff: 최신순이므로 첫 오래된 것 발견 시 즉시 종료
+          if (since && publishedAt && publishedAt.getTime() <= since.getTime()) {
+            stopAfterPage = true;
+            break;
           }
 
-          // 대댓글 (replies가 있는 경우)
+          comments.push({
+            sourceId: topComment.id ?? '',
+            parentId: null,
+            videoSourceId: videoId,
+            content: topComment.snippet.textDisplay ?? '',
+            author: topComment.snippet.authorDisplayName ?? '',
+            likeCount: topComment.snippet.likeCount ?? 0,
+            publishedAt,
+            rawData: topComment as unknown as Record<string, unknown>,
+          });
+
           if (thread.replies?.comments) {
             for (const reply of thread.replies.comments) {
               if (!reply.snippet) continue;
+              const replyPublishedAt: Date | null = reply.snippet.publishedAt
+                ? new Date(reply.snippet.publishedAt)
+                : null;
+              // 대댓글은 since 필터만 (종료는 topLevel이 결정)
+              if (since && replyPublishedAt && replyPublishedAt.getTime() <= since.getTime()) {
+                continue;
+              }
               comments.push({
                 sourceId: reply.id ?? '',
-                parentId: topComment?.id ?? null,
+                parentId: topComment.id ?? null,
                 videoSourceId: videoId,
                 content: reply.snippet.textDisplay ?? '',
                 author: reply.snippet.authorDisplayName ?? '',
                 likeCount: reply.snippet.likeCount ?? 0,
-                publishedAt: reply.snippet.publishedAt ? new Date(reply.snippet.publishedAt) : null,
+                publishedAt: replyPublishedAt,
                 rawData: reply as unknown as Record<string, unknown>,
               });
             }
@@ -104,14 +127,13 @@ export class YoutubeCommentsCollector implements Collector<YoutubeComment> {
           yield comments;
         }
 
-        // 다음 페이지 토큰 확인
+        if (stopAfterPage) break;
+
         nextPageToken = response.data.nextPageToken ?? undefined;
         if (!nextPageToken) break;
       } catch (err: unknown) {
-        // 댓글이 비활성화된 영상 -- 403 에러 시 graceful skip
         const error = err as { code?: number; message?: string };
         if (error.code === 403) {
-          // 댓글 비활성화 영상 -- 건너뛰기
           break;
         }
         throw err;

--- a/packages/collectors/tests/naver-comments.incremental.test.ts
+++ b/packages/collectors/tests/naver-comments.incremental.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { NaverCommentsCollector } from '../src/adapters/naver-comments';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonpReply(
+  comments: Array<{ commentNo: string; regTime: string; contents: string }>,
+  totalPages = 1,
+): Response {
+  const payload = {
+    result: {
+      commentList: comments.map((c) => ({
+        commentNo: c.commentNo,
+        regTime: c.regTime,
+        modTime: c.regTime,
+        contents: c.contents,
+        sympathyCount: 0,
+        antipathyCount: 0,
+        maskedUserId: 'x',
+      })),
+      pageModel: { totalPages },
+    },
+  };
+  const body = `_callback(${JSON.stringify(payload)});`;
+  return { ok: true, status: 200, text: async () => body } as Response;
+}
+
+describe('NaverCommentsCollector 증분 수집', () => {
+  it('since 이후의 댓글만 반환한다', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonpReply([
+        { commentNo: '3', regTime: '2026-04-21T10:00:00Z', contents: 'new' },
+        { commentNo: '2', regTime: '2026-04-20T10:00:00Z', contents: 'old1' },
+        { commentNo: '1', regTime: '2026-04-19T10:00:00Z', contents: 'old2' },
+      ]),
+    );
+
+    const collector = new NaverCommentsCollector();
+    const url = 'https://n.news.naver.com/article/001/0000000001';
+    const since = new Date('2026-04-20T12:00:00Z');
+
+    const collected: string[] = [];
+    for await (const chunk of collector.collectForArticle(url, { maxComments: 100, since })) {
+      for (const c of chunk) collected.push(c.sourceId);
+    }
+
+    expect(collected).toEqual(['3']);
+  });
+
+  it('since 이전 댓글이 연속 20개 나오면 조기 종료한다', async () => {
+    // 100개 중 앞 5개만 since 이후, 나머지 95개는 since 이전 → 연속 20개 충족 시 break
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      commentNo: String(1000 - i),
+      regTime:
+        i < 5
+          ? `2026-04-21T${String(10 - i).padStart(2, '0')}:00:00Z`
+          : `2026-04-19T${String(10 - (i % 10)).padStart(2, '0')}:00:00Z`,
+      contents: `c${i}`,
+    }));
+    // totalPages=5로 설정하되 실제로는 연속 20개 cutoff로 페이지 1에서 종료될 것
+    mockFetch.mockResolvedValue(jsonpReply(items, 5));
+
+    const collector = new NaverCommentsCollector();
+    const url = 'https://n.news.naver.com/article/001/0000000001';
+    const since = new Date('2026-04-20T12:00:00Z');
+
+    const collected: string[] = [];
+    for await (const chunk of collector.collectForArticle(url, { maxComments: 500, since })) {
+      for (const c of chunk) collected.push(c.sourceId);
+    }
+
+    // 페이지 1에서 연속 20개 cutoff 감지 → 페이지 2 이후 호출 없음
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(collected.length).toBe(5);
+  });
+
+  it('since 미지정 시 기존 동작(전량 수집, FAVORITE 정렬) 유지', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonpReply(
+        [
+          { commentNo: '2', regTime: '2026-04-19T10:00:00Z', contents: 'a' },
+          { commentNo: '1', regTime: '2026-04-18T10:00:00Z', contents: 'b' },
+        ],
+        1,
+      ),
+    );
+
+    const collector = new NaverCommentsCollector();
+    const url = 'https://n.news.naver.com/article/001/0000000001';
+    const collected: string[] = [];
+    for await (const chunk of collector.collectForArticle(url, { maxComments: 100 })) {
+      for (const c of chunk) collected.push(c.sourceId);
+    }
+    expect(collected).toEqual(['2', '1']);
+    const firstCallUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstCallUrl).toMatch(/sort=FAVORITE/);
+  });
+
+  it('since 지정 시 호출 URL에 sort=NEW가 포함된다', async () => {
+    mockFetch.mockResolvedValueOnce(jsonpReply([], 0));
+    const collector = new NaverCommentsCollector();
+    const url = 'https://n.news.naver.com/article/001/0000000001';
+    for await (const _ of collector.collectForArticle(url, {
+      maxComments: 10,
+      since: new Date('2026-04-20T00:00:00Z'),
+    })) {
+      // drain
+    }
+    const firstCallUrl = mockFetch.mock.calls[0][0] as string;
+    expect(firstCallUrl).toMatch(/sort=NEW/);
+  });
+});

--- a/packages/collectors/tests/youtube-comments.incremental.test.ts
+++ b/packages/collectors/tests/youtube-comments.incremental.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { YoutubeCommentsCollector } from '../src/adapters/youtube-comments';
+
+const listMock = vi.fn();
+
+// vi.mock은 hoist되어 import보다 먼저 실행되므로 아래 선언 위치와 무관하게 동작한다.
+vi.mock('../src/utils/youtube-client', () => ({
+  getYoutubeClient: () => ({
+    commentThreads: { list: listMock },
+  }),
+}));
+
+function mkThread(id: string, publishedAt: string) {
+  return {
+    snippet: {
+      topLevelComment: {
+        id,
+        snippet: {
+          textDisplay: `c${id}`,
+          authorDisplayName: 'u',
+          likeCount: 0,
+          publishedAt,
+        },
+      },
+    },
+    replies: null,
+  };
+}
+
+beforeEach(() => {
+  listMock.mockReset();
+});
+
+describe('YoutubeCommentsCollector 증분 수집', () => {
+  it('since 이후의 댓글만 반환한다', async () => {
+    listMock.mockResolvedValueOnce({
+      data: {
+        items: [
+          mkThread('3', '2026-04-21T10:00:00Z'),
+          mkThread('2', '2026-04-20T10:00:00Z'),
+          mkThread('1', '2026-04-19T10:00:00Z'),
+        ],
+        nextPageToken: undefined,
+      },
+    });
+
+    const collector = new YoutubeCommentsCollector();
+    const collected: string[] = [];
+    for await (const chunk of collector.collect({
+      keyword: 'video-xyz',
+      startDate: '2026-04-01T00:00:00Z',
+      endDate: '2026-04-30T00:00:00Z',
+      maxComments: 100,
+      since: '2026-04-20T12:00:00Z',
+      commentOrder: 'time',
+    })) {
+      for (const c of chunk) collected.push(c.sourceId);
+    }
+
+    expect(collected).toEqual(['3']);
+    expect(listMock.mock.calls[0][0]).toMatchObject({ order: 'time', videoId: 'video-xyz' });
+  });
+
+  it('publishedAt<=since 발견 시 즉시 종료(후속 페이지 호출 없음)', async () => {
+    listMock.mockResolvedValueOnce({
+      data: {
+        items: [mkThread('5', '2026-04-21T11:00:00Z'), mkThread('4', '2026-04-20T09:00:00Z')],
+        nextPageToken: 'PAGE2',
+      },
+    });
+
+    const collector = new YoutubeCommentsCollector();
+    const collected: string[] = [];
+    for await (const chunk of collector.collect({
+      keyword: 'video-xyz',
+      startDate: '2026-04-01T00:00:00Z',
+      endDate: '2026-04-30T00:00:00Z',
+      maxComments: 100,
+      since: '2026-04-20T12:00:00Z',
+      commentOrder: 'time',
+    })) {
+      for (const c of chunk) collected.push(c.sourceId);
+    }
+    expect(collected).toEqual(['5']);
+    expect(listMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('since 미지정 시 기존 order=relevance 동작 유지', async () => {
+    listMock.mockResolvedValueOnce({
+      data: { items: [mkThread('1', '2026-04-21T10:00:00Z')], nextPageToken: undefined },
+    });
+    const collector = new YoutubeCommentsCollector();
+    for await (const _ of collector.collect({
+      keyword: 'video-xyz',
+      startDate: '2026-04-01T00:00:00Z',
+      endDate: '2026-04-30T00:00:00Z',
+      maxComments: 100,
+    })) {
+      // drain
+    }
+    expect(listMock.mock.calls[0][0]).toMatchObject({ order: 'relevance' });
+  });
+});

--- a/packages/core/src/analysis/__tests__/item-analyzer.incremental.test.ts
+++ b/packages/core/src/analysis/__tests__/item-analyzer.incremental.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { buildItemAnalysisQueries } from '../item-analyzer';
+
+describe('buildItemAnalysisQueries — 증분 쿼리', () => {
+  it('articles 쿼리가 sentiment IS NULL 조건을 포함한다', () => {
+    const { articleQuery } = buildItemAnalysisQueries(42);
+    const sql = articleQuery.toSQL().sql.toLowerCase();
+    // sentiment IS NULL이 WHERE 절에 있어야 함 (대소문자 불문)
+    expect(sql).toMatch(/"articles"\.\s*"sentiment"\s+is\s+null|articles.*sentiment.*is null/);
+  });
+
+  it('comments 쿼리가 sentiment IS NULL 조건을 포함한다', () => {
+    const { commentQuery } = buildItemAnalysisQueries(42);
+    const sql = commentQuery.toSQL().sql.toLowerCase();
+    expect(sql).toMatch(/"comments"\.\s*"sentiment"\s+is\s+null|comments.*sentiment.*is null/);
+  });
+
+  it('jobId 필터가 articleJobs/commentJobs 조인에 포함된다', () => {
+    const { articleQuery, commentQuery } = buildItemAnalysisQueries(42);
+    expect(articleQuery.toSQL().sql).toMatch(/article_jobs/i);
+    expect(commentQuery.toSQL().sql).toMatch(/comment_jobs/i);
+  });
+});

--- a/packages/core/src/analysis/item-analyzer.ts
+++ b/packages/core/src/analysis/item-analyzer.ts
@@ -1,5 +1,5 @@
-// 개별 기사/댓글 감정 분석 (경량 BERT 모델 단일 패스)
-import { eq, sql } from 'drizzle-orm';
+// 개별 기사/댓글 감정 분석 (경량 BERT 모델 단일 패스, 증분)
+import { and, eq, isNull, sql } from 'drizzle-orm';
 import { getDb } from '../db';
 import {
   articles,
@@ -76,27 +76,32 @@ export async function analyzeItems(jobId: number): Promise<{
   // 경량 모델 초기화
   await initClassifier();
 
-  // 기사/댓글 병렬 로드
-  const [articleRows, commentRows] = await Promise.all([
+  // 기사/댓글 병렬 로드 — 증분: sentiment가 아직 NULL인 row만
+  const { articleQuery, commentQuery } = buildItemAnalysisQueries(jobId);
+  const [articleRows, commentRows, articlesSkipped, commentsSkipped] = await Promise.all([
+    articleQuery,
+    commentQuery,
     db
-      .select({ id: articles.id, title: articles.title, content: articles.content })
+      .select({ count: sql<number>`count(*)::int` })
       .from(articles)
       .innerJoin(articleJobs, eq(articles.id, articleJobs.articleId))
-      .where(eq(articleJobs.jobId, jobId)),
+      .where(and(eq(articleJobs.jobId, jobId), sql`${articles.sentiment} IS NOT NULL`))
+      .then((rows) => rows[0]?.count ?? 0),
     db
-      .select({ id: comments.id, content: comments.content })
+      .select({ count: sql<number>`count(*)::int` })
       .from(comments)
       .innerJoin(commentJobs, eq(comments.id, commentJobs.commentId))
-      .where(eq(commentJobs.jobId, jobId)),
+      .where(and(eq(commentJobs.jobId, jobId), sql`${comments.sentiment} IS NOT NULL`))
+      .then((rows) => rows[0]?.count ?? 0),
   ]);
 
-  const articlesTotal = articleRows.length;
-  const commentsTotal = commentRows.length;
+  const articlesTotal = articleRows.length + articlesSkipped;
+  const commentsTotal = commentRows.length + commentsSkipped;
 
   await appendJobEvent(
     jobId,
     'info',
-    `개별 감정 분석 시작 (기사 ${articlesTotal}건, 댓글 ${commentsTotal}건)`,
+    `개별 감정 분석 시작 (신규: 기사 ${articleRows.length}건, 댓글 ${commentRows.length}건 | 이미 분류됨: 기사 ${articlesSkipped}건, 댓글 ${commentsSkipped}건)`,
   );
 
   await updateJobProgress(jobId, {
@@ -107,6 +112,8 @@ export async function analyzeItems(jobId: number): Promise<{
       commentsTotal,
       articlesAnalyzed: 0,
       commentsAnalyzed: 0,
+      articlesSkipped,
+      commentsSkipped,
     },
   });
 
@@ -223,4 +230,23 @@ export async function analyzeItems(jobId: number): Promise<{
 
   console.log(`[item-analyzer] 완료: 기사 ${articlesAnalyzed}건, 댓글 ${commentsAnalyzed}건`);
   return { articlesAnalyzed, commentsAnalyzed };
+}
+
+/**
+ * analyzeItems의 증분 로드 쿼리를 별도 export — 테스트/재사용 용도.
+ * sentiment가 아직 NULL인 row만 대상.
+ */
+export function buildItemAnalysisQueries(jobId: number) {
+  const db = getDb();
+  const articleQuery = db
+    .select({ id: articles.id, title: articles.title, content: articles.content })
+    .from(articles)
+    .innerJoin(articleJobs, eq(articles.id, articleJobs.articleId))
+    .where(and(eq(articleJobs.jobId, jobId), isNull(articles.sentiment)));
+  const commentQuery = db
+    .select({ id: comments.id, content: comments.content })
+    .from(comments)
+    .innerJoin(commentJobs, eq(comments.id, commentJobs.commentId))
+    .where(and(eq(commentJobs.jobId, jobId), isNull(comments.sentiment)));
+  return { articleQuery, commentQuery };
 }

--- a/packages/core/src/db/schema/collections.ts
+++ b/packages/core/src/db/schema/collections.ts
@@ -195,6 +195,7 @@ export const comments = pgTable(
     rawData: jsonb('raw_data'),
     embedding: vector384('embedding'), // pgvector 임베딩 (multilingual-e5-small, 384차원)
     collectedAt: timestamp('collected_at').defaultNow().notNull(),
+    firstSeenAt: timestamp('first_seen_at').defaultNow().notNull(),
   },
   (table) => [uniqueIndex('comments_source_id_idx').on(table.source, table.sourceId)],
 );

--- a/packages/core/src/pipeline/__tests__/reuse-planner.refetch-spec.test.ts
+++ b/packages/core/src/pipeline/__tests__/reuse-planner.refetch-spec.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  RefetchCommentSpec,
+  RefetchCommentSpecVideo,
+  ArticleReusePlan,
+  VideoReusePlan,
+} from '../reuse-planner';
+
+describe('reuse-planner refetch spec 타입', () => {
+  it('RefetchCommentSpec은 url/articleId/lastCommentsFetchedAt을 가진다', () => {
+    const spec: RefetchCommentSpec = {
+      url: 'https://example.com/a/1',
+      articleId: 42,
+      lastCommentsFetchedAt: new Date('2026-04-20T10:00:00Z'),
+    };
+    expect(spec.url).toBe('https://example.com/a/1');
+    expect(spec.articleId).toBe(42);
+    expect(spec.lastCommentsFetchedAt?.toISOString()).toBe('2026-04-20T10:00:00.000Z');
+  });
+
+  it('RefetchCommentSpec의 lastCommentsFetchedAt은 null을 허용한다', () => {
+    const spec: RefetchCommentSpec = {
+      url: 'https://example.com/a/1',
+      articleId: 42,
+      lastCommentsFetchedAt: null,
+    };
+    expect(spec.lastCommentsFetchedAt).toBeNull();
+  });
+
+  it('ArticleReusePlan.refetchCommentsFor는 RefetchCommentSpec 배열이다', () => {
+    const plan: ArticleReusePlan = {
+      reuseArticleIds: [1, 2],
+      skipUrls: ['https://example.com/a/1'],
+      refetchCommentsFor: [
+        { url: 'https://example.com/a/2', articleId: 2, lastCommentsFetchedAt: null },
+      ],
+      evaluated: 2,
+    };
+    expect(plan.refetchCommentsFor[0].articleId).toBe(2);
+  });
+
+  it('VideoReusePlan.refetchCommentsFor는 RefetchCommentSpecVideo 배열이다', () => {
+    const spec: RefetchCommentSpecVideo = {
+      url: 'https://youtube.com/watch?v=abc',
+      videoId: 7,
+      lastCommentsFetchedAt: null,
+    };
+    const plan: VideoReusePlan = {
+      reuseVideoIds: [7],
+      skipVideoUrls: [],
+      refetchCommentsFor: [spec],
+      evaluated: 1,
+    };
+    expect(plan.refetchCommentsFor[0].videoId).toBe(7);
+  });
+});

--- a/packages/core/src/pipeline/persist.ts
+++ b/packages/core/src/pipeline/persist.ts
@@ -153,6 +153,7 @@ export async function persistComments(jobId: number, data: (typeof comments.$inf
       const rows = await tx
         .insert(comments)
         .values(batch)
+        // first_seen_at은 onConflictDoUpdate.set에서 의도적으로 제외 — 최초 등장 시점 보존
         .onConflictDoUpdate({
           target: [comments.source, comments.sourceId],
           set: {

--- a/packages/core/src/pipeline/reuse-planner.ts
+++ b/packages/core/src/pipeline/reuse-planner.ts
@@ -18,10 +18,28 @@ export interface ReusePlanInput {
   forceRefetch?: boolean;
 }
 
+/**
+ * 본문 재사용 대상 중 "댓글만 새로 긁어야 할" 기사의 스펙.
+ * URL뿐 아니라 articleId/lastCommentsFetchedAt을 함께 전달해 어댑터가
+ * since 기반 증분 수집을 할 수 있게 한다.
+ */
+export interface RefetchCommentSpec {
+  url: string;
+  articleId: number;
+  lastCommentsFetchedAt: Date | null;
+}
+
+/** 영상용 RefetchCommentSpec (videoId 필드 사용) */
+export interface RefetchCommentSpecVideo {
+  url: string;
+  videoId: number;
+  lastCommentsFetchedAt: Date | null;
+}
+
 export interface ArticleReusePlan {
   reuseArticleIds: number[]; // articleJobs 재연결 대상 (본문·댓글 모두 스킵)
   skipUrls: string[]; // collector 가 검색 결과에서 제외할 URL
-  refetchCommentsFor: string[]; // 본문 skip, 댓글만 fetch
+  refetchCommentsFor: RefetchCommentSpec[]; // 본문 skip, 댓글만 fetch (since 증분 포함)
   // 디버깅·모니터링용
   evaluated: number; // 후보 개수 (DB hit 기사)
 }
@@ -29,7 +47,7 @@ export interface ArticleReusePlan {
 export interface VideoReusePlan {
   reuseVideoIds: number[];
   skipVideoUrls: string[];
-  refetchCommentsFor: string[];
+  refetchCommentsFor: RefetchCommentSpecVideo[];
   evaluated: number;
 }
 
@@ -98,15 +116,19 @@ export async function planArticleReuse(input: ReusePlanInput): Promise<ArticleRe
 
   const reuseArticleIds: number[] = [];
   const skipUrls: string[] = [];
-  const refetchCommentsFor: string[] = [];
+  const refetchCommentsFor: RefetchCommentSpec[] = [];
 
   for (const row of candidates) {
     reuseArticleIds.push(row.id);
     const commentsStale =
       !row.lastCommentsFetchedAt || row.lastCommentsFetchedAt.getTime() < commentCutoffMs;
     if (commentsStale) {
-      // 본문은 스킵하지만 댓글만 새로 긁기 — 검색 결과 URL 매칭용
-      refetchCommentsFor.push(row.url);
+      // 본문은 스킵하지만 댓글만 새로 긁기 — 어댑터에 since(lastCommentsFetchedAt) 전달용
+      refetchCommentsFor.push({
+        url: row.url,
+        articleId: row.id,
+        lastCommentsFetchedAt: row.lastCommentsFetchedAt ?? null,
+      });
     } else {
       // 본문·댓글 모두 스킵
       skipUrls.push(row.url);
@@ -163,14 +185,18 @@ export async function planVideoReuse(input: ReusePlanInput): Promise<VideoReuseP
 
   const reuseVideoIds: number[] = [];
   const skipVideoUrls: string[] = [];
-  const refetchCommentsFor: string[] = [];
+  const refetchCommentsFor: RefetchCommentSpecVideo[] = [];
 
   for (const row of candidates) {
     reuseVideoIds.push(row.id);
     const commentsStale =
       !row.lastCommentsFetchedAt || row.lastCommentsFetchedAt.getTime() < commentCutoffMs;
     if (commentsStale) {
-      refetchCommentsFor.push(row.url);
+      refetchCommentsFor.push({
+        url: row.url,
+        videoId: row.id,
+        lastCommentsFetchedAt: row.lastCommentsFetchedAt ?? null,
+      });
     } else {
       skipVideoUrls.push(row.url);
     }

--- a/packages/core/src/queue/__tests__/triggerClassify.test.ts
+++ b/packages/core/src/queue/__tests__/triggerClassify.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+
+describe('triggerClassify', () => {
+  it('flows 모듈에서 triggerClassify 함수가 export된다', async () => {
+    const { triggerClassify } = await import('../flows');
+    expect(typeof triggerClassify).toBe('function');
+  });
+
+  it('triggerClassify는 2개의 인자를 받는다 (dbJobId, keyword)', async () => {
+    const { triggerClassify } = await import('../flows');
+    expect(triggerClassify.length).toBe(2);
+  });
+});

--- a/packages/core/src/queue/collector-worker.ts
+++ b/packages/core/src/queue/collector-worker.ts
@@ -25,7 +25,15 @@ export function createCollectorHandler(): (job: Job) => Promise<CollectorResult>
       job.data;
     const dataSourceSnapshot = job.data.dataSourceSnapshot as DataSourceSnapshot | undefined;
     const reusePlan = job.data.reusePlan as
-      | { skipUrls: string[]; refetchCommentsFor: string[] }
+      | {
+          skipUrls: string[];
+          refetchCommentsFor: Array<{
+            url: string;
+            articleId?: number;
+            videoId?: number;
+            lastCommentsFetchedAt: string | null;
+          }>;
+        }
       | undefined;
 
     // 동적 소스(RSS/HTML)면 factory로 인스턴스 생성, 아니면 기존 정적 registry 조회

--- a/packages/core/src/queue/flows.ts
+++ b/packages/core/src/queue/flows.ts
@@ -476,6 +476,9 @@ export async function triggerClassify(dbJobId: number, keyword: string) {
     queueName: 'pipeline',
     data: { dbJobId, keyword },
     opts: {
+      // 멱등성 보장: persist가 재시도되어도 동일 dbJobId에 대해 classify는 1번만 enqueue됨.
+      // BullMQ는 같은 jobId를 가진 두 번째 add를 무시한다.
+      jobId: `classify:${dbJobId}`,
       removeOnComplete: { age: 3600 },
       removeOnFail: { age: 86400 },
     },

--- a/packages/core/src/queue/flows.ts
+++ b/packages/core/src/queue/flows.ts
@@ -99,10 +99,15 @@ async function safePlanVideoReuse(
 
 function toReusePlanPayload(plan: ArticleReusePlan | VideoReusePlan): ReusePlanPayload {
   const skipUrls = 'skipUrls' in plan ? plan.skipUrls : plan.skipVideoUrls;
-  return {
-    skipUrls,
-    refetchCommentsFor: plan.refetchCommentsFor,
-  };
+  const refetchCommentsFor = plan.refetchCommentsFor.map((spec) => ({
+    url: spec.url,
+    ...('articleId' in spec ? { articleId: spec.articleId } : {}),
+    ...('videoId' in spec ? { videoId: spec.videoId } : {}),
+    lastCommentsFetchedAt: spec.lastCommentsFetchedAt
+      ? spec.lastCommentsFetchedAt.toISOString()
+      : null,
+  }));
+  return { skipUrls, refetchCommentsFor };
 }
 
 // dbJobId: collection_jobs 테이블의 정수 PK -- 호출자가 createCollectionJob() 후 전달

--- a/packages/core/src/queue/flows.ts
+++ b/packages/core/src/queue/flows.ts
@@ -465,6 +465,24 @@ export async function triggerCollection(params: CollectionTrigger, dbJobId: numb
   return { flowId, dbJobId, flow };
 }
 
+/**
+ * 개별 감정 분류 트리거 — persist 완료 후 호출.
+ * classify 노드는 pipeline 큐에서 돌며, 완료 시 triggerAnalysis를 자동으로 이어서 호출한다.
+ * BERT 모델은 pipeline-worker 프로세스에 이미 상주 — 별도 워커 없이 재사용.
+ */
+export async function triggerClassify(dbJobId: number, keyword: string) {
+  const flow = await getFlowProducer().add({
+    name: 'classify',
+    queueName: 'pipeline',
+    data: { dbJobId, keyword },
+    opts: {
+      removeOnComplete: { age: 3600 },
+      removeOnFail: { age: 86400 },
+    },
+  });
+  return flow;
+}
+
 // D-09: 분석 파이프라인 트리거 -- persist 완료 후 호출
 // runner.ts가 내부적으로 3단계 병렬/순차를 관리하므로 Flow는 단일 작업으로 단순화
 export async function triggerAnalysis(dbJobId: number, keyword: string) {

--- a/packages/core/src/queue/flows.ts
+++ b/packages/core/src/queue/flows.ts
@@ -263,7 +263,13 @@ export async function triggerCollection(params: CollectionTrigger, dbJobId: numb
     children.push({
       name: 'normalize-naver',
       queueName: 'pipeline',
-      data: { source: 'naver-news', flowId, dbJobId, maxComments: limits.commentsPerItem },
+      data: {
+        source: 'naver-news',
+        flowId,
+        dbJobId,
+        maxComments: limits.commentsPerItem,
+        reusePlan, // Task 12: pipeline-worker가 URL별 since 맵 구성용
+      },
       children: [
         {
           name: 'collect-naver-articles',

--- a/packages/core/src/queue/pipeline-worker.ts
+++ b/packages/core/src/queue/pipeline-worker.ts
@@ -23,6 +23,7 @@ import {
   updateJobProgress,
   linkArticleKeywords,
   linkVideoKeywords,
+  appendJobEvent,
 } from '../pipeline';
 import { getDb } from '../db';
 import { dataSources } from '../db/schema/sources';
@@ -33,7 +34,8 @@ import {
   persistArticleEmbeddings,
   persistCommentEmbeddings,
 } from '../analysis/preprocessing/embedding-persist';
-import { triggerAnalysis } from './flows';
+import { analyzeItems } from '../analysis/item-analyzer';
+import { triggerAnalysis, triggerClassify } from './flows';
 import { COMMUNITY_SOURCES } from './worker-config';
 
 const logger = createLogger('pipeline-worker');
@@ -532,22 +534,56 @@ export function createPipelineHandler(): (job: Job) => Promise<any> {
       logger.info(`[persist] 완료: ${persistElapsed}초 소요 (dbJobId=${dbJobId})`);
 
       // D-09: 수집 완료 후 자동 분석 트리거
-      // 취소 확인 — persist 완료 후에도 취소되었으면 분석 트리거하지 않음
+      // 취소 확인 — persist 완료 후에도 취소되었으면 분류/분석 트리거하지 않음
       const keyword = job.data.keyword;
       if (keyword) {
         if (dbJobId && (await isPipelineCancelled(dbJobId))) {
-          logger.info(`[persist] 취소됨 — 분석 트리거 건너뜀 (dbJobId=${dbJobId})`);
+          logger.info(`[persist] 취소됨 — classify 트리거 건너뜀 (dbJobId=${dbJobId})`);
         } else {
-          // BP 게이트: 정규화 완료 후 (analysis 트리거 직전)
-          if (dbJobId && !(await awaitStageGate(dbJobId, 'normalize'))) {
-            return { cancelled: true };
-          }
-          await triggerAnalysis(dbJobId, keyword);
-          logger.info(`분석 파이프라인 트리거됨: job=${dbJobId}, keyword=${keyword}`);
+          // classify 노드가 내부적으로 게이트 확인 후 triggerAnalysis 호출
+          await triggerClassify(dbJobId, keyword);
+          logger.info(`classify 노드 트리거됨: job=${dbJobId}, keyword=${keyword}`);
         }
       }
 
       return { persisted: true };
+    }
+
+    // classify 분기: 증분 개별 감정 분석 + triggerAnalysis
+    if (job.name === 'classify') {
+      const { dbJobId: classifyJobId, keyword: classifyKeyword } = job.data;
+
+      if (await isPipelineCancelled(classifyJobId)) {
+        logger.info(`[classify] 취소됨 — 스킵 (dbJobId=${classifyJobId})`);
+        return { skipped: true, reason: 'cancelled' };
+      }
+
+      // 증분 item-analysis — 실패해도 분석은 계속 진행
+      try {
+        await analyzeItems(classifyJobId);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn(`[classify] item-analysis 실패 (분석은 계속): ${msg}`);
+        await appendJobEvent(
+          classifyJobId,
+          'warn',
+          `개별 감정 분석 실패 (분석은 계속 진행됨): ${msg}`,
+        ).catch(() => void 0);
+      }
+
+      // BP 게이트: 정규화 완료 후 (analysis 트리거 직전)
+      if (!(await awaitStageGate(classifyJobId, 'normalize'))) {
+        logger.info(`[classify] 게이트 미통과 — 분석 트리거 건너뜀 (dbJobId=${classifyJobId})`);
+        return { cancelled: true };
+      }
+
+      if (classifyKeyword) {
+        await triggerAnalysis(classifyJobId, classifyKeyword);
+        logger.info(
+          `[classify] 분석 파이프라인 트리거됨: job=${classifyJobId}, keyword=${classifyKeyword}`,
+        );
+      }
+      return { classified: true };
     }
   };
 }

--- a/packages/core/src/queue/pipeline-worker.ts
+++ b/packages/core/src/queue/pipeline-worker.ts
@@ -80,6 +80,19 @@ export function createPipelineHandler(): (job: Job) => Promise<any> {
         const maxComments = (job.data.maxComments as number) ?? 500;
         const allComments: NaverComment[] = [];
 
+        // 재사용된 기사의 since 맵 — 이 URL들은 댓글만 증분으로 새로 긁는다
+        const refetchSpecs = (job.data.reusePlan?.refetchCommentsFor ?? []) as Array<{
+          url: string;
+          articleId?: number;
+          lastCommentsFetchedAt: string | null;
+        }>;
+        const urlToSince = new Map<string, Date | null>(
+          refetchSpecs.map((s) => [
+            s.url,
+            s.lastCommentsFetchedAt ? new Date(s.lastCommentsFetchedAt) : null,
+          ]),
+        );
+
         // 기사별 댓글 수집 진행 추적
         const articleDetails: Array<{ title: string; status: string; comments: number }> = articles
           .filter((a) => a.url)
@@ -118,9 +131,14 @@ export function createPipelineHandler(): (job: Job) => Promise<any> {
           detail.status = 'running';
           const collector = new NaverCommentsCollector();
           const articleComments: NaverComment[] = [];
+          // 재사용 대상이면 since 전달, 신규 기사면 전량 수집
+          const since = urlToSince.get(item.url) ?? undefined;
 
           try {
-            for await (const chunk of collector.collectForArticle(item.url, { maxComments })) {
+            for await (const chunk of collector.collectForArticle(item.url, {
+              maxComments,
+              since: since ?? undefined,
+            })) {
               articleComments.push(...chunk);
               detail.comments = articleComments.length;
               await updateProgress();

--- a/packages/core/src/queue/pipeline-worker.ts
+++ b/packages/core/src/queue/pipeline-worker.ts
@@ -232,6 +232,9 @@ export function createPipelineHandler(): (job: Job) => Promise<any> {
       }
 
       // 하위 호환: 기존 YoutubeVideosCollector로 수집된 결과 처리
+      // NOTE: 이 경로는 "신규 영상 수집 → 댓글 후처리" 전용이며, TTL 재사용된 영상은
+      //       신규 YoutubeCollector(통합형)의 refetchCommentsOnly 경로에서 처리된다.
+      //       따라서 여기서는 since 주입이 불필요 — 모든 영상이 신규 수집 대상이다.
       if (job.name === 'normalize-youtube' && results['youtube-videos'] && !results['youtube']) {
         const videos = (
           results['youtube-videos'] as { items: Array<{ sourceId: string; title?: string }> }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -32,9 +32,21 @@ export type CollectionTrigger = z.infer<typeof CollectionTriggerSchema>;
  * 각 collector adapter 는 skipUrls 를 검색 결과에서 제외하고,
  * refetchCommentsFor 에 해당하는 URL 은 본문 fetch 없이 댓글만 수집한다.
  */
+/**
+ * 본문 재사용 대상 중 "댓글만 새로 수집할" 항목의 BullMQ 직렬화 형태.
+ * Date는 ISO 문자열로 전달 (BullMQ가 JSON 직렬화).
+ * articleId/videoId 중 하나만 세팅 (수집 계통이 다른 두 테이블 구분).
+ */
+export interface RefetchCommentSpecPayload {
+  url: string;
+  articleId?: number;
+  videoId?: number;
+  lastCommentsFetchedAt: string | null;
+}
+
 export interface ReusePlanPayload {
   skipUrls: string[]; // 본문+댓글 모두 스킵
-  refetchCommentsFor: string[]; // 본문은 스킵, 댓글만 새로 수집
+  refetchCommentsFor: RefetchCommentSpecPayload[]; // 본문 스킵, 댓글만 증분 수집
 }
 
 export type SourceStatus = {


### PR DESCRIPTION
## Summary

- **댓글 증분 수집**: 네이버/유튜브 댓글 어댑터가 `since` (lastCommentsFetchedAt) 옵션을 받아 이미 수집한 댓글은 스킵. `sort=NEW` / `order=time`으로 정렬 전환 + 연속 OLD 20개 cutoff.
- **최초 등장 시점 보존**: `comments.first_seen_at DEFAULT now()` 컬럼 추가. `persistComments`의 `onConflictDoUpdate.set`에서 제외되어 upsert 시에도 보존.
- **개별 감정 분석을 수집 단계로 이동**: 새 `classify` 큐 노드(pipeline 큐 재사용)가 `persist` 직후 증분 `analyzeItems`를 돌린 뒤 `triggerAnalysis`를 호출. 재사용된 기사·댓글은 `sentiment IS NULL` 필터로 BERT 재호출 스킵.
- **커뮤니티 어댑터는 변경 없음** (YAGNI): `first_seen_at` + `ON CONFLICT DO NOTHING` 정책만으로 최초 등장 시점 보존 + 중복 저장 방지 달성.

**스펙**: `docs/technical/specs/2026-04-21-수집단계-증분감정-design.md`
**플랜**: `docs/technical/plans/2026-04-21-수집단계-증분감정-plan.md`

## 주요 변경 파일

| 파일 | 변경 |
|---|---|
| `packages/core/src/db/schema/collections.ts` | `comments.firstSeenAt` 추가 |
| `packages/core/src/pipeline/reuse-planner.ts` | `RefetchCommentSpec` 타입, articleId/videoId/lastCommentsFetchedAt 번들 반환 |
| `packages/core/src/queue/flows.ts` | `triggerClassify` 헬퍼, 멱등성 jobId |
| `packages/core/src/queue/pipeline-worker.ts` | `classify` 분기 핸들러, 네이버 댓글 수집부에 since 주입 |
| `packages/core/src/analysis/item-analyzer.ts` | `isNull(sentiment)` 필터, `articlesSkipped`/`commentsSkipped` 카운트 |
| `packages/collectors/src/adapters/naver-comments.ts` | `collectForArticle(url, {since, sort})` |
| `packages/collectors/src/adapters/youtube-comments.ts` | `since` 해석, `order=time` 강제 |
| `packages/collectors/src/adapters/youtube-collector.ts` | `collectCommentsViaApi`에 since cutoff |

## Test plan

정적 검증(완료):
- [x] `pnpm --filter @ai-signalcraft/core build` 통과
- [x] `pnpm --filter @ai-signalcraft/collectors build` 통과
- [x] core 테스트 322 passed (신규 9건 추가), collectors 테스트 116 passed (신규 7건 추가)
- [x] 워커 프로세스 기동 로그 정상 (`ais-dev` prefix)
- [x] `triggerClassify` 호출 시 `name='classify', queue='pipeline'` BullMQ job 생성 확인

운영 배포 후 E2E 검증(할 일):
- [ ] 운영 DB에 `pnpm db:push` → `first_seen_at` 컬럼 추가
- [ ] `dserver restart ais-collector-worker`
- [ ] 새 키워드 1회 수집 → classify 노드 로그 확인
- [ ] 같은 키워드 TTL 내 2회차 수집 → `first_seen_at` 보존 확인 (psql)
- [ ] 2회차에서 네이버/유튜브 신규 댓글만 증가 확인
- [ ] progress JSON에 `articlesSkipped`/`commentsSkipped` 표시 확인
- [ ] 분석 재실행 시 Stage 0 소요 시간 5초 이하 확인

## 실패 격리 정책

- **BERT 실패**: classify 핸들러가 try/catch로 감싸고 `appendJobEvent('warn', ...)` 후 분석은 sentiment=NULL 상태로 계속 진행
- **취소**: classify 진입 시/직전 `isPipelineCancelled` 체크 → 분석 트리거도 하지 않음
- **classify 이중 디스패치**: `jobId='classify:\${dbJobId}'` BullMQ 멱등성 키로 방지

## Rollout

1. PR 리뷰 및 승인
2. main 병합
3. 운영 DB 마이그레이션 (`pnpm db:push`)
4. 운영 워커 재시작 (`dserver restart ais-collector-worker`)
5. 1건 수집 트리거로 스모크 테스트
6. 1주 모니터링 (`progress._events`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)