### PR TITLE
fix(queue): triggerClassify jobId 콜론 제거 (긴급)

### DIFF
--- a/packages/core/src/queue/flows.ts
+++ b/packages/core/src/queue/flows.ts
@@ -478,7 +478,8 @@ export async function triggerClassify(dbJobId: number, keyword: string) {
     opts: {
       // 멱등성 보장: persist가 재시도되어도 동일 dbJobId에 대해 classify는 1번만 enqueue됨.
       // BullMQ는 같은 jobId를 가진 두 번째 add를 무시한다.
-      jobId: `classify:${dbJobId}`,
+      // 주의: BullMQ는 jobId에 ':' 문자를 금지하므로 언더스코어 사용.
+      jobId: `classify_${dbJobId}`,
       removeOnComplete: { age: 3600 },
       removeOnFail: { age: 86400 },
     },


### PR DESCRIPTION
## Summary

PR #122의 regression hotfix.

\`triggerClassify\`의 \`jobId: \`classify:\${dbJobId}\`\` 가 BullMQ의 "Custom Id cannot contain ':'" 규칙을 위반하여 **새 수집 트리거 시 persist 말미에서 매번 실패**합니다. 분석 단계가 아예 큐에 올라가지 않는 심각한 상태.

## Cause

PR #122 코드 리뷰에서 멱등성 보장을 위해 추가한 jobId에 콜론을 사용. BullMQ 제약을 미처 확인하지 못함 (로컬 테스트는 triggerClassify 스모크만 돌려봤을 뿐 멱등성 조합은 실제로 안 돌아봄).

## Fix

콜론 → 언더스코어. 멱등성 기능은 그대로 유지.

\`\`\`diff
-      jobId: \`classify:\${dbJobId}\`,
+      // 주의: BullMQ는 jobId에 ':' 문자를 금지하므로 언더스코어 사용.
+      jobId: \`classify_\${dbJobId}\`,
\`\`\`

## Verification

- \`pnpm --filter @ai-signalcraft/core build\` 통과
- 테스트 322 passed / 6 skipped (변동 없음)
- 로컬에서 tsx 스크립트로 운영 Redis에 classify job 투입 확인 (수정 후 TRIGGERED 로그 정상)

## Impact

빠른 머지 권장. 머지 후:
1. Deploy 워크플로우 자동 실행으로 \`ais-prod-worker\` 재배포
2. dashboard에서 수집 1건 트리거 → classify 노드 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)