### PR TITLE
fix(collector): 하이퍼테이블 UNIQUE INDEX 누락 재발 방지 3단 가드

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,20 @@ jobs:
           pnpm --filter @ai-signalcraft/core db:push
           echo "DB schema synced"
 
+      - name: Collector Hypertable DDL (UNIQUE INDEX, compression, retention)
+        shell: bash -l {0}
+        run: |
+          source ~/.nvm/nvm.sh
+          # 하이퍼테이블 UNIQUE INDEX는 Drizzle push로 표현 불가 → apply-hypertables.ts (멱등) 실행.
+          # 누락 시 executor의 ON CONFLICT가 실패해 모든 수집 run이 failed로 쌓임 (과거 2회 재발).
+          export DATABASE_URL=$(grep ^COLLECTOR_DATABASE_URL .env.production | sed 's/COLLECTOR_DATABASE_URL=//' | sed 's|@host.docker.internal:5435|@localhost:5435|')
+          if [ -z "$DATABASE_URL" ]; then
+            echo "COLLECTOR_DATABASE_URL missing in .env.production"
+            exit 1
+          fi
+          pnpm --filter @ai-signalcraft/collector db:migrate-timescale
+          echo "Collector hypertable DDL applied"
+
       - name: Generate Release Draft
         shell: bash -l {0}
         continue-on-error: true

--- a/apps/collector/src/db/migrations/verify-hypertable-constraints.test.ts
+++ b/apps/collector/src/db/migrations/verify-hypertable-constraints.test.ts
@@ -1,0 +1,74 @@
+/* eslint-disable import-x/order */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const executeMock = vi.fn();
+vi.mock('../index', () => ({
+  getDb: () => ({ execute: executeMock }),
+}));
+
+import {
+  verifyHypertableConstraints,
+  assertHypertableConstraints,
+} from './verify-hypertable-constraints';
+
+describe('verifyHypertableConstraints', () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+  });
+
+  it('모든 UNIQUE INDEX가 존재하면 ok=true', async () => {
+    executeMock.mockResolvedValue({ rows: [{ indexname: 'raw_items_dedup_uniq' }] });
+    const r = await verifyHypertableConstraints();
+    expect(r.ok).toBe(true);
+    expect(r.missing).toEqual([]);
+  });
+
+  it('UNIQUE INDEX가 누락되면 missing에 힌트 포함해 반환', async () => {
+    executeMock.mockResolvedValue({ rows: [] });
+    const r = await verifyHypertableConstraints();
+    expect(r.ok).toBe(false);
+    expect(r.missing).toHaveLength(1);
+    expect(r.missing[0]).toContain('raw_items.raw_items_dedup_uniq');
+    expect(r.missing[0]).toContain('ON CONFLICT');
+  });
+});
+
+describe('assertHypertableConstraints', () => {
+  const exitSpy = vi.spyOn(process, 'exit');
+  const errorSpy = vi.spyOn(console, 'error');
+
+  beforeEach(() => {
+    executeMock.mockReset();
+    exitSpy.mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    errorSpy.mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    exitSpy.mockReset();
+    errorSpy.mockReset();
+  });
+
+  it('정상 상태에서는 exit하지 않음', async () => {
+    executeMock.mockResolvedValue({ rows: [{ indexname: 'raw_items_dedup_uniq' }] });
+    await expect(assertHypertableConstraints()).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('누락 시 기본(hard-fail)은 process.exit(1) + 에러 로그', async () => {
+    executeMock.mockResolvedValue({ rows: [] });
+    await expect(assertHypertableConstraints()).rejects.toThrow('process.exit(1)');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const logged = errorSpy.mock.calls.flat().join('\n');
+    expect(logged).toContain('db:migrate-timescale');
+  });
+
+  it('softFail=true이면 exit하지 않고 경고만', async () => {
+    executeMock.mockResolvedValue({ rows: [] });
+    await expect(assertHypertableConstraints({ softFail: true })).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    const logged = errorSpy.mock.calls.flat().join('\n');
+    expect(logged).toContain('db:migrate-timescale');
+  });
+});

--- a/apps/collector/src/db/migrations/verify-hypertable-constraints.ts
+++ b/apps/collector/src/db/migrations/verify-hypertable-constraints.ts
@@ -1,0 +1,66 @@
+import { sql } from 'drizzle-orm';
+import { getDb } from '../index';
+
+/**
+ * 하이퍼테이블의 필수 UNIQUE INDEX 존재를 확인.
+ *
+ * raw_items에 `raw_items_dedup_uniq (source, source_id, item_type, time)`가 없으면
+ * executor의 `ON CONFLICT (source, source_id, item_type, time) DO NOTHING`이
+ * "there is no unique or exclusion constraint matching the ON CONFLICT specification"으로 실패하며
+ * 모든 수집 run이 failed로 쌓인다 (2026-04-20 dcinside, 2026-04-21 이재명 구독 전체 소스 장애 사례).
+ *
+ * 운영 환경에서 `pnpm db:push` 뒤 `pnpm db:migrate-timescale`이 누락되는 사고가 반복되므로
+ * 워커 부팅 시 이 검증으로 즉시 실패(exit 1)시켜 장애를 조기에 노출한다.
+ */
+export type HypertableVerificationResult = {
+  ok: boolean;
+  missing: string[];
+};
+
+const REQUIRED_UNIQUE_INDEXES = [
+  {
+    tableName: 'raw_items',
+    indexName: 'raw_items_dedup_uniq',
+    hint: 'ON CONFLICT (source, source_id, item_type, time) DO NOTHING',
+  },
+] as const;
+
+export async function verifyHypertableConstraints(): Promise<HypertableVerificationResult> {
+  const db = getDb();
+  const missing: string[] = [];
+
+  for (const { tableName, indexName, hint } of REQUIRED_UNIQUE_INDEXES) {
+    const rows = await db.execute<{ indexname: string }>(sql`
+      SELECT indexname FROM pg_indexes
+      WHERE tablename = ${tableName} AND indexname = ${indexName}
+    `);
+    if (rows.rows.length === 0) {
+      missing.push(`${tableName}.${indexName} (required for: ${hint})`);
+    }
+  }
+
+  return { ok: missing.length === 0, missing };
+}
+
+/**
+ * 부팅 단계에서 호출해 누락 시 프로세스를 종료.
+ * `softFail=true`면 경고만 출력하고 진행(HTTP 서버처럼 읽기만 하는 프로세스용).
+ */
+export async function assertHypertableConstraints(options?: { softFail?: boolean }): Promise<void> {
+  const { ok, missing } = await verifyHypertableConstraints();
+  if (ok) return;
+
+  const lines = [
+    '[db-verify] ✗ hypertable UNIQUE INDEX missing:',
+    ...missing.map((m) => `  - ${m}`),
+    '  run: pnpm --filter @ai-signalcraft/collector db:migrate-timescale',
+  ];
+  const message = lines.join('\n');
+
+  if (options?.softFail) {
+    console.error(message);
+    return;
+  }
+  console.error(message);
+  process.exit(1);
+}

--- a/apps/collector/src/queue/worker-process.ts
+++ b/apps/collector/src/queue/worker-process.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import { Worker, type WorkerOptions } from 'bullmq';
 import { hasYoutubeApiKey } from '@ai-signalcraft/collectors';
+import { assertHypertableConstraints } from '../db/migrations/verify-hypertable-constraints';
 import { getBullMQOptions } from './connection';
 import {
   COLLECTOR_SOURCES,
@@ -109,6 +110,8 @@ export async function shutdownWorkers(
  * docker-compose의 collector-worker 서비스가 사용.
  */
 async function main() {
+  console.warn('[worker-process] verifying hypertable constraints...');
+  await assertHypertableConstraints();
   console.warn('[worker-process] starting all source workers...');
   const workers = startAllWorkers();
   console.warn(

--- a/apps/collector/src/scripts/backfill-sentiment.ts
+++ b/apps/collector/src/scripts/backfill-sentiment.ts
@@ -8,7 +8,7 @@
  *   pnpm --filter collector tsx src/scripts/backfill-sentiment.ts --item-type comment
  *   pnpm --filter collector tsx src/scripts/backfill-sentiment.ts --dry-run
  */
-import { sql, isNull, and, eq } from 'drizzle-orm';
+import { sql, isNull, and, eq, type SQL } from 'drizzle-orm';
 import { getDb } from '../db';
 import { rawItems } from '../db/schema';
 import { initSentiment, classifySentimentFromTexts } from '../services/sentiment';
@@ -28,7 +28,7 @@ async function main() {
   await initSentiment();
 
   const db = getDb();
-  const conditions = [isNull(rawItems.sentiment)];
+  const conditions: SQL[] = [isNull(rawItems.sentiment)];
   if (subscriptionId) conditions.push(eq(rawItems.subscriptionId, Number(subscriptionId)));
   if (source) conditions.push(eq(rawItems.source, source));
   if (itemType) conditions.push(eq(rawItems.itemType, itemType as 'article' | 'video' | 'comment'));
@@ -53,7 +53,7 @@ async function main() {
   let lastSourceId: string | null = null;
 
   while (true) {
-    const cursorConditions = lastTime
+    const cursorConditions: SQL[] = lastTime
       ? [
           ...conditions,
           sql`(${rawItems.time}, ${rawItems.sourceId}) > (${lastTime}, ${lastSourceId})`,

--- a/apps/collector/src/server/index.ts
+++ b/apps/collector/src/server/index.ts
@@ -3,6 +3,7 @@ import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import type { TRPCError } from '@trpc/server';
+import { assertHypertableConstraints } from '../db/migrations/verify-hypertable-constraints';
 import { appRouter } from './trpc/router';
 import { createCollectorContext } from './trpc/init';
 
@@ -10,6 +11,8 @@ const PORT = Number(process.env.PORT ?? 3400);
 const HOST = process.env.HOST ?? '0.0.0.0';
 
 async function main() {
+  await assertHypertableConstraints({ softFail: true });
+
   const server = Fastify({
     logger: {
       level: process.env.LOG_LEVEL ?? 'info',


### PR DESCRIPTION
## Summary

- 배포 파이프라인에 `db:migrate-timescale` 단계 추가 — 멱등 스크립트가 매 배포마다 `raw_items_dedup_uniq` 보장
- `worker-process` 부팅 시 hard-fail 검증 — INDEX 누락이면 `process.exit(1)`로 조기 노출
- `collector API` 부팅 시 soft-fail 검증 — 읽기 API 가용성 유지

## Context

2026-04-21 이재명 구독(259)의 5개 소스가 전부 `there is no unique or exclusion constraint matching the ON CONFLICT specification`로 실패. 운영 DB(`ais_collection.raw_items`)에 `raw_items_dedup_uniq (source, source_id, item_type, time)` UNIQUE INDEX가 누락된 상태였음.

즉각 조치로 `db:migrate-timescale` 수동 실행해 복구했으나, 2026-04-20(dcinside)에 이어 **두 번째 재발**이라 근본 해결 필요. 원인은 `db:push`가 하이퍼테이블 UNIQUE를 관리할 수 없는 구조적 문제 + 배포 체크리스트 누락.

## Test plan

- [x] `verify-hypertable-constraints.test.ts` 5개 테스트 통과 (정상/누락/softFail)
- [x] 실제 운영 DB 대상 smoke: `ok: true`
- [x] lint clean, 신규 파일 타입체크 clean
- [ ] 배포 후 `ais-collector-worker` 로그에서 `[worker-process] verifying hypertable constraints...` 출력 확인
- [ ] 배포 로그에서 `Collector hypertable DDL applied` 스텝 성공 확인
- [ ] 다음 스케줄 수집이 정상 완료되는지 모니터 UI 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)