### PR TITLE
feat(core): Phase 1 PR1 — persistFromCollectorPayload 신규

### DIFF
--- a/packages/core/src/pipeline/persist-from-collector.ts
+++ b/packages/core/src/pipeline/persist-from-collector.ts
@@ -1,0 +1,43 @@
+// 구독 단축 경로(useCollectorLoader=true)에서 collector가 반환한 fullset payload를
+// 분석 DB의 articles/comments/videos에 upsert하고, article_jobs/comment_jobs/video_jobs
+// linkage 테이블에 INSERT한다.
+//
+// 일반 경로의 collect → normalize → persist 잡을 우회하므로, persist만 별도로 호출해서
+// linkage가 비는 결함(job 271 사례)을 막는다.
+import type { articles, videos, comments } from '../db/schema/collections';
+import { persistArticles, persistVideos, persistComments } from './persist';
+
+export type CollectorFullsetPayload = {
+  articles: (typeof articles.$inferInsert)[];
+  videos: (typeof videos.$inferInsert)[];
+  comments: (typeof comments.$inferInsert)[];
+};
+
+export type PersistFromCollectorResult = {
+  articles: number;
+  videos: number;
+  comments: number;
+};
+
+/**
+ * collector payload를 분석 DB로 영속화 + linkage 채우기.
+ *
+ * - 본문은 onConflictDoUpdate로 갱신 (`persistArticles` 등 재사용)
+ * - linkage(article_jobs/video_jobs/comment_jobs)는 onConflictDoNothing — 같은 잡 재실행 안전
+ * - 트랜잭션은 테이블별로 분리(기존 패턴 유지) — articles 실패 시 comments는 롤백 안 됨
+ */
+export async function persistFromCollectorPayload(
+  jobId: number,
+  payload: CollectorFullsetPayload,
+): Promise<PersistFromCollectorResult> {
+  const [articleRows, videoRows, commentRows] = await Promise.all([
+    persistArticles(jobId, payload.articles),
+    persistVideos(jobId, payload.videos),
+    persistComments(jobId, payload.comments),
+  ]);
+  return {
+    articles: articleRows.length,
+    videos: videoRows.length,
+    comments: commentRows.length,
+  };
+}

--- a/packages/core/tests/persist-from-collector.test.ts
+++ b/packages/core/tests/persist-from-collector.test.ts
@@ -39,4 +39,14 @@ describe('persistFromCollectorPayload', () => {
     expect(persist.persistVideos).toHaveBeenCalledWith(99, []);
     expect(persist.persistComments).toHaveBeenCalledWith(99, []);
   });
+
+  it('propagates rejection from persistArticles', async () => {
+    const persist = await import('../src/pipeline/persist');
+    (persist.persistArticles as never as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('DB down'),
+    );
+    await expect(
+      persistFromCollectorPayload(42, { articles: [], videos: [], comments: [] }),
+    ).rejects.toThrow('DB down');
+  });
 });

--- a/packages/core/tests/persist-from-collector.test.ts
+++ b/packages/core/tests/persist-from-collector.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { persistFromCollectorPayload } from '../src/pipeline/persist-from-collector';
+
+vi.mock('../src/pipeline/persist', () => ({
+  persistArticles: vi.fn().mockResolvedValue([{ id: 1 }, { id: 2 }]),
+  persistVideos: vi.fn().mockResolvedValue([{ id: 10 }]),
+  persistComments: vi.fn().mockResolvedValue([{ id: 100 }, { id: 101 }, { id: 102 }]),
+}));
+
+describe('persistFromCollectorPayload', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns counts for each table', async () => {
+    const result = await persistFromCollectorPayload(42, {
+      articles: [{ source: 'naver-news', sourceId: 'a1', url: 'u', title: 't' } as never],
+      videos: [{ source: 'youtube', sourceId: 'v1', url: 'u', title: 't' } as never],
+      comments: [{ source: 'naver-comments', sourceId: 'c1', content: 'x' } as never],
+    });
+    expect(result).toEqual({ articles: 2, videos: 1, comments: 3 });
+  });
+
+  it('handles empty payload', async () => {
+    const persist = await import('../src/pipeline/persist');
+    (persist.persistArticles as never as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    (persist.persistVideos as never as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    (persist.persistComments as never as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    const result = await persistFromCollectorPayload(42, {
+      articles: [],
+      videos: [],
+      comments: [],
+    });
+    expect(result).toEqual({ articles: 0, videos: 0, comments: 0 });
+  });
+
+  it('passes jobId to all three persist functions', async () => {
+    const persist = await import('../src/pipeline/persist');
+    await persistFromCollectorPayload(99, { articles: [], videos: [], comments: [] });
+    expect(persist.persistArticles).toHaveBeenCalledWith(99, []);
+    expect(persist.persistVideos).toHaveBeenCalledWith(99, []);
+    expect(persist.persistComments).toHaveBeenCalledWith(99, []);
+  });
+});


### PR DESCRIPTION
## Summary
- 구독 단축 경로(useCollectorLoader=true)에서 collector fullset을 분석 DB로 영속화 + linkage(article_jobs/comment_jobs/video_jobs) 채우는 신규 함수 도입.
- 일반 경로의 \`persistArticles\`/\`persistVideos\`/\`persistComments\`를 재사용.
- 이 PR에서는 함수만 도입, 호출자는 PR4에서 추가 (행동 변화 없음).

## Files
- \`packages/core/src/pipeline/persist-from-collector.ts\` (신규)
- \`packages/core/tests/persist-from-collector.test.ts\` (신규, 4 케이스)

## Spec
\`docs/superpowers/specs/2026-04-26-subscription-pipeline-data-loss-fix-design.md\` Section 3 (Phase 1).

## Test plan
- [x] vitest: persistFromCollectorPayload 4 cases passing
- [x] vitest: 전체 회귀 없음 (332 passed)
- [x] lint, build 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)