### PR TITLE
feat: Phase 1 PR4 — subscription pipeline data integrity (271 회귀 게이트)

### DIFF
--- a/apps/web/src/server/trpc/routers/__tests__/analysis-trigger-subscription.test.ts
+++ b/apps/web/src/server/trpc/routers/__tests__/analysis-trigger-subscription.test.ts
@@ -1,0 +1,102 @@
+/**
+ * buildSubscriptionAnalysisMeta 단위 테스트
+ *
+ * triggerSubscription mutation은 router import 시 Redis/DB 연결 부작용이 발생하므로
+ * 메타 합성 로직을 순수 헬퍼(buildSubscriptionAnalysisMeta)로 분리하여 직접 검증합니다.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildSubscriptionAnalysisMeta } from '../subscription-analysis-meta';
+
+describe('buildSubscriptionAnalysisMeta', () => {
+  it('appliedPreset/limits/options.sources를 spec 대로 합성', () => {
+    const result = buildSubscriptionAnalysisMeta(
+      {
+        keyword: '한동훈',
+        sources: ['naver-news', 'youtube', 'dcinside', 'fmkorea', 'clien'],
+        limits: { maxPerRun: 500, commentsPerItem: 200 },
+      },
+      { subscriptionId: 37 },
+    );
+
+    // appliedPreset
+    expect(result.appliedPreset.slug).toBe('__subscription__');
+    expect(result.appliedPreset.title).toContain('한동훈');
+    expect(result.appliedPreset.sources).toEqual({
+      'naver-news': true,
+      youtube: true,
+      dcinside: true,
+      fmkorea: true,
+      clien: true,
+    });
+    expect(result.appliedPreset.optimization).toBe('rag-standard');
+    expect(result.appliedPreset.customized).toBe(true);
+    expect(result.appliedPreset.enableItemAnalysis).toBe(false);
+
+    // limits: maxPerRun(500) 폴백 → naverArticles/youtubeVideos/communityPosts 모두 500
+    expect(result.limits).toEqual({
+      naverArticles: 500,
+      youtubeVideos: 500,
+      communityPosts: 500,
+      commentsPerItem: 200,
+    });
+
+    // options
+    expect(result.options).toEqual({
+      subscriptionId: 37,
+      skipItemAnalysis: true,
+      useCollectorLoader: true,
+      tokenOptimization: 'rag-standard',
+      sources: ['naver-news', 'youtube', 'dcinside', 'fmkorea', 'clien'],
+    });
+  });
+
+  it('소스별 전용 limits가 있으면 maxPerRun보다 우선', () => {
+    const result = buildSubscriptionAnalysisMeta(
+      {
+        keyword: 'test',
+        sources: ['naver-news'],
+        limits: {
+          maxPerRun: 100,
+          naverArticles: 300,
+          youtubeVideos: 25,
+          communityPosts: 80,
+          commentsPerItem: 50,
+        },
+      },
+      { subscriptionId: 1 },
+    );
+
+    expect(result.limits).toEqual({
+      naverArticles: 300,
+      youtubeVideos: 25,
+      communityPosts: 80,
+      commentsPerItem: 50,
+    });
+  });
+
+  it('limits/sources 없을 때 기본값 적용', () => {
+    const result = buildSubscriptionAnalysisMeta(
+      { keyword: 'empty', sources: null, limits: null },
+      { subscriptionId: 99 },
+    );
+
+    expect(result.appliedPreset.sources).toEqual({});
+    expect(result.limits).toEqual({
+      naverArticles: 500,
+      youtubeVideos: 50,
+      communityPosts: 100,
+      commentsPerItem: 200,
+    });
+    expect(result.options.sources).toEqual([]);
+  });
+
+  it('optimizationPreset 지정 시 반영', () => {
+    const result = buildSubscriptionAnalysisMeta(
+      { keyword: 'test', sources: [], limits: {} },
+      { subscriptionId: 1, optimizationPreset: 'aggressive' },
+    );
+
+    expect(result.appliedPreset.optimization).toBe('aggressive');
+    expect(result.options.tokenOptimization).toBe('aggressive');
+  });
+});

--- a/apps/web/src/server/trpc/routers/analysis.ts
+++ b/apps/web/src/server/trpc/routers/analysis.ts
@@ -19,6 +19,7 @@ import {
 import { protectedProcedure, router } from '../init';
 import { buildJobCondition } from '../shared/query-helpers';
 import { applyDemoGuard } from '../shared/demo-guard';
+import { buildSubscriptionAnalysisMeta } from './subscription-analysis-meta';
 
 export const analysisRouter = router({
   // 분석 트리거 -- 키워드/소스/기간으로 수집+분석 파이프라인 시작
@@ -346,7 +347,17 @@ export const analysisRouter = router({
         throw new TRPCError({ code: 'BAD_REQUEST', message: '비활성 구독입니다.' });
       }
 
-      // 2. collection_jobs 레코드 생성
+      // 2. 운영 가시성 메타 합성 (순수 함수 — 단위 테스트 대상)
+      const meta = buildSubscriptionAnalysisMeta(
+        {
+          keyword: sub.keyword,
+          sources: sub.sources,
+          limits: sub.limits as Record<string, number> | null,
+        },
+        { subscriptionId: input.subscriptionId, optimizationPreset: input.optimizationPreset },
+      );
+
+      // 3. collection_jobs 레코드 생성
       const [job] = await ctx.db
         .insert(collectionJobs)
         .values({
@@ -356,18 +367,15 @@ export const analysisRouter = router({
           status: 'running',
           domain: input.domain || sub.domain || 'general',
           userId: ctx.userId,
-          options: {
-            subscriptionId: input.subscriptionId,
-            skipItemAnalysis: true,
-            useCollectorLoader: true,
-            tokenOptimization: input.optimizationPreset ?? 'rag-standard',
-          },
+          appliedPreset: meta.appliedPreset,
+          limits: meta.limits,
+          options: meta.options,
         })
         .returning({ id: collectionJobs.id });
 
       if (!job) throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: '잡 생성 실패' });
 
-      // 3. 단축 경로 — analysis 큐에 직접 등록
+      // 4. 단축 경로 — analysis 큐에 직접 등록
       await triggerSubscriptionAnalysis(job.id, sub.keyword);
 
       return { jobId: job.id, keyword: sub.keyword };

--- a/apps/web/src/server/trpc/routers/subscription-analysis-meta.ts
+++ b/apps/web/src/server/trpc/routers/subscription-analysis-meta.ts
@@ -1,0 +1,95 @@
+/**
+ * buildSubscriptionAnalysisMeta — 순수 헬퍼
+ *
+ * triggerSubscription mutation에서 collection_jobs에 저장할 appliedPreset/limits/options를
+ * 구독 정보로부터 합성합니다. 외부 의존 없이 단위 테스트 가능하도록 별도 파일로 분리합니다.
+ */
+
+type TokenOptimization =
+  | 'none'
+  | 'light'
+  | 'standard'
+  | 'aggressive'
+  | 'rag-light'
+  | 'rag-standard'
+  | 'rag-aggressive';
+
+export type SubscriptionJobMeta = {
+  appliedPreset: {
+    slug: string;
+    title: string;
+    sources: Record<string, boolean>;
+    limits: {
+      naverArticles: number;
+      youtubeVideos: number;
+      communityPosts: number;
+      commentsPerItem: number;
+    };
+    optimization: TokenOptimization;
+    skippedModules: string[];
+    enableItemAnalysis: boolean;
+    customized: boolean;
+  };
+  limits: {
+    naverArticles: number;
+    youtubeVideos: number;
+    communityPosts: number;
+    commentsPerItem: number;
+  };
+  options: {
+    subscriptionId: number;
+    skipItemAnalysis: boolean;
+    useCollectorLoader: boolean;
+    tokenOptimization: TokenOptimization;
+    sources: string[];
+  };
+};
+
+export function buildSubscriptionAnalysisMeta(
+  sub: {
+    keyword: string;
+    sources?: string[] | null;
+    limits?: Record<string, number> | null;
+  },
+  args: {
+    subscriptionId: number;
+    optimizationPreset?: TokenOptimization;
+  },
+): SubscriptionJobMeta {
+  const subscriptionSources = (sub.sources ?? []) as string[];
+  const subscriptionLimits = (sub.limits ?? {}) as Record<string, number>;
+  const tokenOptimization: TokenOptimization = args.optimizationPreset ?? 'rag-standard';
+
+  const limits = {
+    naverArticles: subscriptionLimits.naverArticles ?? subscriptionLimits.maxPerRun ?? 500,
+    youtubeVideos: subscriptionLimits.youtubeVideos ?? subscriptionLimits.maxPerRun ?? 50,
+    communityPosts: subscriptionLimits.communityPosts ?? subscriptionLimits.maxPerRun ?? 100,
+    commentsPerItem: subscriptionLimits.commentsPerItem ?? 200,
+  };
+
+  const appliedPreset = {
+    slug: '__subscription__',
+    title: `구독 #${args.subscriptionId} (${sub.keyword})`,
+    sources: subscriptionSources.reduce<Record<string, boolean>>((acc, s) => {
+      acc[s] = true;
+      return acc;
+    }, {}),
+    limits,
+    optimization: tokenOptimization,
+    skippedModules: [] as string[],
+    enableItemAnalysis: false,
+    customized: true,
+  };
+
+  return {
+    appliedPreset,
+    limits,
+    options: {
+      subscriptionId: args.subscriptionId,
+      skipItemAnalysis: true,
+      useCollectorLoader: true,
+      tokenOptimization,
+      sources: subscriptionSources,
+    },
+  };
+}

--- a/packages/core/src/analysis/data-loader.ts
+++ b/packages/core/src/analysis/data-loader.ts
@@ -199,9 +199,11 @@ export async function loadAnalysisInputViaCollector(
 
   const VALID_SOURCES = ['naver-news', 'youtube', 'dcinside', 'fmkorea', 'clien'] as const;
   type ValidSource = (typeof VALID_SOURCES)[number];
-  const optsSources = (opts?.sources as string[] | undefined)?.filter((s): s is ValidSource =>
-    (VALID_SOURCES as readonly string[]).includes(s),
-  );
+  const optsSources = Array.isArray(opts?.sources)
+    ? (opts.sources as string[]).filter((s): s is ValidSource =>
+        (VALID_SOURCES as readonly string[]).includes(s),
+      )
+    : undefined;
 
   return loadAnalysisInputFromCollector({
     jobId,

--- a/packages/core/src/analysis/data-loader.ts
+++ b/packages/core/src/analysis/data-loader.ts
@@ -197,6 +197,12 @@ export async function loadAnalysisInputViaCollector(
       ? tokenOpt
       : undefined;
 
+  const VALID_SOURCES = ['naver-news', 'youtube', 'dcinside', 'fmkorea', 'clien'] as const;
+  type ValidSource = (typeof VALID_SOURCES)[number];
+  const optsSources = (opts?.sources as string[] | undefined)?.filter((s): s is ValidSource =>
+    (VALID_SOURCES as readonly string[]).includes(s),
+  );
+
   return loadAnalysisInputFromCollector({
     jobId,
     keyword: job.keyword,
@@ -206,6 +212,7 @@ export async function loadAnalysisInputViaCollector(
     },
     domain: (job.domain as AnalysisDomain) || undefined,
     subscriptionId: (opts?.subscriptionId as number) || undefined,
+    sources: optsSources,
     ragPreset,
   });
 }

--- a/packages/core/src/analysis/pipeline-orchestrator.ts
+++ b/packages/core/src/analysis/pipeline-orchestrator.ts
@@ -101,7 +101,7 @@ export async function runAnalysisPipeline(
     const collectorResult = loadResult as CollectorAnalysisResult;
     await updateJobProgress(jobId, {
       persist: { status: 'running', source: 'collector' },
-    });
+    }).catch((err) => logError('pipeline-orchestrator', err));
     try {
       const persistResult = await persistFromCollectorPayload(jobId, collectorResult.fullset);
       await updateJobProgress(jobId, {
@@ -112,7 +112,7 @@ export async function runAnalysisPipeline(
           videos: persistResult.videos,
           comments: persistResult.comments,
         },
-      });
+      }).catch((err) => logError('pipeline-orchestrator', err));
     } catch (err) {
       await updateJobProgress(jobId, {
         persist: {
@@ -120,7 +120,7 @@ export async function runAnalysisPipeline(
           source: 'collector',
           error: err instanceof Error ? err.message : String(err),
         },
-      });
+      }).catch((err) => logError('pipeline-orchestrator', err));
       // 분석 자체는 RAG sample 입력으로 계속 진행 (linkage 누락은 가시성 손실이지 분석 차단 아님)
       try {
         await appendJobEvent(
@@ -128,8 +128,8 @@ export async function runAnalysisPipeline(
           'warn',
           `persistFromCollectorPayload 실패: ${err instanceof Error ? err.message : String(err)}`,
         );
-      } catch {
-        // 이벤트 로깅 실패는 무시
+      } catch (err) {
+        logError('pipeline-orchestrator', err);
       }
     }
   }
@@ -179,7 +179,7 @@ export async function runAnalysisPipeline(
 
   // 구독 단축 경로: collector API에서 로드한 데이터 통계를 progress에 기록
   // (수집/정규화 단계가 없으므로 UI에서 건수를 표시할 수 있도록)
-  if (options?.useCollectorLoader || jobOptions.useCollectorLoader) {
+  if (isCollectorPath) {
     const subStats: Record<
       string,
       { status: string; articles: number; comments: number; videos: number }
@@ -315,7 +315,7 @@ export async function runAnalysisPipeline(
   // 분석 측 ragRetrieve(분석 DB articles 검색)는 구독 경로에서 무효화되어 있어 우회한다.
   // 시계열 후샘플(stratifiedSample)만 호출해 한도 내로 줄이면서 시간 분포를 보존.
   const usingCollectorRag =
-    (options?.useCollectorLoader || jobOptions.useCollectorLoader) &&
+    isCollectorPath &&
     (tokenOptimization === 'rag-light' ||
       tokenOptimization === 'rag-standard' ||
       tokenOptimization === 'rag-aggressive');

--- a/packages/core/src/analysis/pipeline-orchestrator.ts
+++ b/packages/core/src/analysis/pipeline-orchestrator.ts
@@ -8,6 +8,7 @@ import { evaluateAlerts } from '../alerts';
 import { getDb } from '../db';
 import { collectionJobs } from '../db/schema/collections';
 import { recordStageDuration, withSpan } from '../metrics';
+import { persistFromCollectorPayload } from '../pipeline/persist-from-collector';
 import { finalSummaryModule } from './modules';
 import {
   runModule,
@@ -21,6 +22,7 @@ import {
   loadAnalysisInput,
   loadAnalysisInputViaCollector,
   shouldUseCollectorLoader,
+  type CollectorAnalysisResult,
 } from './data-loader';
 import {
   preprocessAnalysisInput,
@@ -83,12 +85,54 @@ export async function runAnalysisPipeline(
     .then((r) => r[0]);
   const jobOptions = (cjRow?.options as Record<string, unknown>) || {};
 
-  const loadResult =
-    options?.useCollectorLoader || jobOptions.useCollectorLoader || shouldUseCollectorLoader()
-      ? await loadAnalysisInputViaCollector(jobId)
-      : await loadAnalysisInput(jobId);
+  const isCollectorPath =
+    options?.useCollectorLoader || jobOptions.useCollectorLoader || shouldUseCollectorLoader();
+
+  const loadResult = isCollectorPath
+    ? await loadAnalysisInputViaCollector(jobId)
+    : await loadAnalysisInput(jobId);
   let input = loadResult.input;
   const samplingStats = loadResult.samplingStats;
+
+  // 구독 단축 경로에서도 article_jobs/comment_jobs/video_jobs를 채워
+  // RAG SQL과 UI 카운트가 일반 경로와 동일한 의미를 갖도록 보장.
+  // (job 271 사례 — linkage 0건 결함 수정)
+  if (isCollectorPath && 'fullset' in loadResult) {
+    const collectorResult = loadResult as CollectorAnalysisResult;
+    await updateJobProgress(jobId, {
+      persist: { status: 'running', source: 'collector' },
+    });
+    try {
+      const persistResult = await persistFromCollectorPayload(jobId, collectorResult.fullset);
+      await updateJobProgress(jobId, {
+        persist: {
+          status: 'completed',
+          source: 'collector',
+          articles: persistResult.articles,
+          videos: persistResult.videos,
+          comments: persistResult.comments,
+        },
+      });
+    } catch (err) {
+      await updateJobProgress(jobId, {
+        persist: {
+          status: 'failed',
+          source: 'collector',
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
+      // 분석 자체는 RAG sample 입력으로 계속 진행 (linkage 누락은 가시성 손실이지 분석 차단 아님)
+      try {
+        await appendJobEvent(
+          jobId,
+          'warn',
+          `persistFromCollectorPayload 실패: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      } catch {
+        // 이벤트 로깅 실패는 무시
+      }
+    }
+  }
 
   // P3: 시계열 샘플링 통계를 progress에 기록 (구간별 입력/샘플 분포)
   // 폴백 동작·시간 편향 디버깅용. items 배열은 빠지므로 페이로드는 작음.

--- a/packages/core/src/db/schema/collections.ts
+++ b/packages/core/src/db/schema/collections.ts
@@ -68,6 +68,8 @@ export const collectionJobs = pgTable(
       skipItemAnalysis?: boolean;
       // CollectorLoader 사용 여부
       useCollectorLoader?: boolean;
+      // 구독 모드에서 수집 대상 소스 목록 스냅샷
+      sources?: string[];
     }>(),
     keywordType: text('keyword_type'),
     domain: text('domain').notNull().default('political'),

--- a/packages/core/tests/analysis-runner.test.ts
+++ b/packages/core/tests/analysis-runner.test.ts
@@ -97,8 +97,21 @@ vi.mock('../src/analysis/data-loader', () => ({
         perBin: [],
       },
     },
+    fullset: { articles: [], videos: [], comments: [] },
+    collectionMeta: {
+      sources: [],
+      sourceCounts: {},
+      window: { start: '', end: '' },
+      truncated: false,
+    },
   }),
   shouldUseCollectorLoader: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../src/pipeline/persist-from-collector', () => ({
+  persistFromCollectorPayload: vi
+    .fn()
+    .mockResolvedValue({ articles: 100, videos: 0, comments: 1000 }),
 }));
 
 vi.mock('../src/analysis/persist-analysis', () => ({
@@ -236,6 +249,89 @@ describe('analysis/runner', () => {
   });
 
   // 통합 테스트 — pipeline-orchestrator가 다수의 DB 쿼리를 수행하므로 DB 연결 필요
+  it('useCollectorLoader=true이면 persistFromCollectorPayload를 호출한다', async () => {
+    const { loadAnalysisInputViaCollector } = await import('../src/analysis/data-loader');
+    const { persistFromCollectorPayload } = await import('../src/pipeline/persist-from-collector');
+    const { updateJobProgress } = await import('../src/pipeline/persist');
+
+    // fullset이 포함된 CollectorAnalysisResult 반환
+    const mockFullset = {
+      articles: [{ source: 'naver-news', sourceId: 'a1', url: 'u', title: 't' } as never],
+      videos: [],
+      comments: [],
+    };
+    (loadAnalysisInputViaCollector as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      input: {
+        jobId: 1,
+        keyword: '테스트',
+        articles: [],
+        videos: [],
+        comments: [],
+        dateRange: { start: new Date('2026-03-01'), end: new Date('2026-03-20') },
+      },
+      samplingStats: {
+        binCount: 0,
+        binIntervalMs: 0,
+        articles: {
+          totalInput: 0,
+          totalSampled: 0,
+          binsUsed: 0,
+          nullPoolSize: 0,
+          nullPoolSampled: 0,
+          perBin: [],
+        },
+        comments: {
+          totalInput: 0,
+          totalSampled: 0,
+          binsUsed: 0,
+          nullPoolSize: 0,
+          nullPoolSampled: 0,
+          perBin: [],
+        },
+        videos: {
+          totalInput: 0,
+          totalSampled: 0,
+          binsUsed: 0,
+          nullPoolSize: 0,
+          nullPoolSampled: 0,
+          perBin: [],
+        },
+      },
+      fullset: mockFullset,
+      collectionMeta: {
+        sources: [],
+        sourceCounts: {},
+        window: { start: '', end: '' },
+        truncated: false,
+      },
+    });
+
+    const { runAnalysisPipeline } = await import('../src/analysis/pipeline-orchestrator');
+    await runAnalysisPipeline(1, { useCollectorLoader: true }).catch(() => {
+      /* 분석 모듈 오류 무시 */
+    });
+
+    expect(persistFromCollectorPayload).toHaveBeenCalledWith(1, mockFullset);
+    expect(updateJobProgress).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        persist: expect.objectContaining({ status: 'running', source: 'collector' }),
+      }),
+    );
+  });
+
+  it('일반 경로(useCollectorLoader=false)는 persistFromCollectorPayload를 호출하지 않는다', async () => {
+    const { persistFromCollectorPayload } = await import('../src/pipeline/persist-from-collector');
+    (persistFromCollectorPayload as ReturnType<typeof vi.fn>).mockClear();
+
+    const { runAnalysisPipeline } = await import('../src/analysis/pipeline-orchestrator');
+    await runAnalysisPipeline(1, { useCollectorLoader: false }).catch(() => {
+      /* 분석 모듈 오류 무시 */
+    });
+
+    expect(persistFromCollectorPayload).not.toHaveBeenCalled();
+  });
+
   it.skipIf(!process.env.DATABASE_URL)(
     'runAnalysisPipeline이 모든 모듈 결과를 반환한다',
     async () => {

--- a/packages/core/tests/subscription-pipeline-regression.test.ts
+++ b/packages/core/tests/subscription-pipeline-regression.test.ts
@@ -1,0 +1,196 @@
+// 271 회귀 가드 — 구독 단축 경로(useCollectorLoader=true)에서 다음을 보장:
+//   1. collector RPC가 options.sources를 그대로 전달함 (5소스)
+//   2. VALID_SOURCES 외 값은 자동 필터됨
+//   3. options.sources 미설정 시 collector에 sources=undefined 전달
+//   4. fullset comment가 parentSourceId → parentId 로 변환됨
+//
+// 본 테스트는 loadAnalysisInputViaCollector 단위 mock 기반.
+// orchestrator의 persistFromCollectorPayload 호출은 analysis-runner.test.ts에서 별도 검증.
+// 실제 DB 통합 검증은 Task 11(수동 검증).
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadAnalysisInputViaCollector } from '../src/analysis/data-loader';
+
+// 1) collector client mock — fetchAnalysisPayload가 ragSample + fullset 반환
+const mockFetchAnalysisPayload = vi.fn();
+vi.mock('../src/collector-client', () => ({
+  getCollectorClient: () => ({
+    items: { fetchAnalysisPayload: { query: mockFetchAnalysisPayload } },
+  }),
+}));
+
+// 2) DB mock — collection_jobs row 반환
+const mockJobSelect = vi.fn();
+vi.mock('../src/db', () => ({
+  getDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => mockJobSelect(),
+        }),
+      }),
+    }),
+  }),
+}));
+
+const baseJob = {
+  id: 271,
+  keyword: '한동훈',
+  startDate: new Date('2026-04-19T04:43:54Z'),
+  endDate: new Date('2026-04-26T04:43:54Z'),
+  domain: 'political',
+  options: {
+    subscriptionId: 37,
+    skipItemAnalysis: true,
+    useCollectorLoader: true,
+    tokenOptimization: 'rag-standard',
+    sources: ['naver-news', 'youtube', 'dcinside', 'fmkorea', 'clien'],
+  },
+};
+
+const emptyPayload = {
+  ragSample: [],
+  fullset: [],
+  collectionMeta: {
+    sources: [],
+    sourceCounts: {},
+    window: {
+      start: baseJob.startDate.toISOString(),
+      end: baseJob.endDate.toISOString(),
+    },
+    truncated: false,
+  },
+};
+
+describe('271 회귀 가드 — 구독 경로 데이터 정합성', () => {
+  beforeEach(() => {
+    mockFetchAnalysisPayload.mockReset();
+    mockJobSelect.mockReset();
+  });
+
+  it('collector RPC 호출 시 sources가 전달된다 (5소스)', async () => {
+    mockJobSelect.mockResolvedValue([baseJob]);
+    mockFetchAnalysisPayload.mockResolvedValue(emptyPayload);
+
+    await loadAnalysisInputViaCollector(271);
+
+    expect(mockFetchAnalysisPayload).toHaveBeenCalledTimes(1);
+    const callArg = mockFetchAnalysisPayload.mock.calls[0][0];
+    expect(callArg.subscriptionId).toBe(37);
+    expect(callArg.sources).toEqual(['naver-news', 'youtube', 'dcinside', 'fmkorea', 'clien']);
+  });
+
+  it('options.sources에 잘못된 값이 섞여도 VALID_SOURCES만 전달', async () => {
+    mockJobSelect.mockResolvedValue([
+      {
+        ...baseJob,
+        options: {
+          ...baseJob.options,
+          sources: ['naver-news', 'naver-comments', 'invalid', 'dcinside'],
+        },
+      },
+    ]);
+    mockFetchAnalysisPayload.mockResolvedValue(emptyPayload);
+
+    await loadAnalysisInputViaCollector(271);
+
+    const callArg = mockFetchAnalysisPayload.mock.calls[0][0];
+    // naver-comments, invalid 제거됨
+    expect(callArg.sources).toEqual(['naver-news', 'dcinside']);
+  });
+
+  it('options.sources 미설정 시 collector에 sources=undefined', async () => {
+    mockJobSelect.mockResolvedValue([
+      {
+        ...baseJob,
+        options: {
+          subscriptionId: 37,
+          skipItemAnalysis: true,
+          useCollectorLoader: true,
+          tokenOptimization: 'rag-standard',
+        },
+      },
+    ]);
+    mockFetchAnalysisPayload.mockResolvedValue(emptyPayload);
+
+    await loadAnalysisInputViaCollector(271);
+
+    const callArg = mockFetchAnalysisPayload.mock.calls[0][0];
+    expect(callArg.sources).toBeUndefined();
+  });
+
+  it('fullset comment의 parentSourceId가 parentId로 변환된다', async () => {
+    mockJobSelect.mockResolvedValue([baseJob]);
+    mockFetchAnalysisPayload.mockResolvedValue({
+      ragSample: [],
+      fullset: [
+        {
+          source: 'naver-news',
+          sourceId: 'a-1',
+          itemType: 'article',
+          url: 'https://example.com/a-1',
+          title: '기사 1',
+          content: '내용',
+          author: null,
+          publisher: 'pub',
+          publishedAt: new Date('2026-04-20T00:00:00Z').toISOString(),
+          parentSourceId: null,
+          metrics: null,
+          sentiment: null,
+          sentimentScore: null,
+          fetchedAt: new Date('2026-04-20T01:00:00Z'),
+          transcript: null,
+          transcriptLang: null,
+          durationSec: null,
+        },
+        {
+          source: 'naver-comments',
+          sourceId: 'c-1',
+          itemType: 'comment',
+          url: 'https://example.com/c-1',
+          title: null,
+          content: '댓글 내용',
+          author: 'user',
+          publisher: null,
+          publishedAt: new Date('2026-04-20T00:00:00Z').toISOString(),
+          parentSourceId: 'a-1',
+          metrics: { likeCount: 3 },
+          sentiment: null,
+          sentimentScore: null,
+          fetchedAt: new Date('2026-04-20T01:00:00Z'),
+          transcript: null,
+          transcriptLang: null,
+          durationSec: null,
+        },
+      ],
+      collectionMeta: {
+        sources: ['naver-news', 'naver-comments'],
+        sourceCounts: {
+          'naver-news': { articles: 1, comments: 0, videos: 0 },
+          'naver-comments': { articles: 0, comments: 1, videos: 0 },
+        },
+        window: {
+          start: baseJob.startDate.toISOString(),
+          end: baseJob.endDate.toISOString(),
+        },
+        truncated: false,
+      },
+    });
+
+    const result = await loadAnalysisInputViaCollector(271);
+
+    expect(result.fullset.articles.length).toBe(1);
+    expect(result.fullset.comments.length).toBe(1);
+    expect(result.fullset.articles[0]).toMatchObject({
+      source: 'naver-news',
+      sourceId: 'a-1',
+      url: 'https://example.com/a-1',
+    });
+    // parentSourceId → parentId 매핑 검증 (p4-collector-rag.test.ts에서 미검증)
+    expect(result.fullset.comments[0]).toMatchObject({
+      source: 'naver-comments',
+      sourceId: 'c-1',
+      content: '댓글 내용',
+      parentId: 'a-1',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
구독 단축 경로의 데이터 정합성 결함 수정의 머지 게이트.

- \`triggerSubscription\` mutation이 \`collection_jobs\`에 \`appliedPreset\`/\`limits\`/\`options.sources\` 스냅샷 저장 (운영 가시성).
- orchestrator가 \`useCollectorLoader\` 분기 직후 \`persistFromCollectorPayload\` 호출 — article_jobs/comment_jobs/video_jobs linkage 채움. progress.persist 단계 기록.
- persist 실패는 분석 차단 안 함 (warn 이벤트로 가시화).
- data-loader가 options.sources를 collector API로 전달 (Array.isArray 가드).
- collectionJobs.options $type에 \`sources?: string[]\` 추가.
- isCollectorPath 변수로 분기 통일 (환경변수 경로 동작 불일치 제거).
- updateJobProgress catch 일관성 회귀 수정.

## 271 회귀 가드
신규 회귀 테스트 \`subscription-pipeline-regression.test.ts\` 4 케이스로 핵심 신호 보호:
- collector RPC가 sources 5개 그대로 전달
- VALID_SOURCES 외 값 자동 필터
- options.sources 미설정 시 undefined 전달
- fullset Drizzle insert 변환 (parentSourceId → parentId)

## 의존성
- ⚠️ **PR1(#126), PR2(#127), PR3(#128) 모두 머지 후** main에 머지 가능. base는 PR3 브랜치.
- 본 PR 브랜치는 PR1을 cherry-pick으로 포함 — PR1 선행 머지 후 squash merge 시 patch가 동일해 자동 정리.

## Files
- \`apps/web/src/server/trpc/routers/analysis.ts\` (수정)
- \`apps/web/src/server/trpc/routers/subscription-analysis-meta.ts\` (신규 헬퍼)
- \`apps/web/src/server/trpc/routers/__tests__/analysis-trigger-subscription.test.ts\` (신규, 4 케이스)
- \`packages/core/src/analysis/pipeline-orchestrator.ts\` (수정)
- \`packages/core/src/analysis/data-loader.ts\` (수정 — options.sources 전달)
- \`packages/core/src/db/schema/collections.ts\` (수정)
- \`packages/core/tests/analysis-runner.test.ts\` (수정)
- \`packages/core/tests/subscription-pipeline-regression.test.ts\` (신규, 4 케이스)

## Spec
Section 3 (Phase 1) of design doc.

## Test plan
- [x] vitest: 신규 회귀 4 + analysis-runner 신규 2 + trigger-subscription 4 = 모두 passing
- [x] 회귀: 전체 342 passed
- [x] 일반 경로(useCollectorLoader=false) 영향 없음 검증

## ⚠️ 주의
이 PR이 머지되면 구독 잡이 **실제로 article_jobs/comment_jobs INSERT를 시작**합니다. 운영 배포 시 Task 11 수동 검증으로 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)