### PR TITLE
feat: Phase 3 PR5 — quality metadata + footer + UI banner

### DIFF
--- a/apps/web/src/__tests__/quality-warning-banner.test.tsx
+++ b/apps/web/src/__tests__/quality-warning-banner.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QualityWarningBanner } from '../components/report/quality-warning-banner';
+
+describe('QualityWarningBanner', () => {
+  it('metadata가 null이면 렌더링 안 함', () => {
+    const { container } = render(<QualityWarningBanner metadata={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('qualityFlags 없으면 렌더링 안 함 (구버전 보고서)', () => {
+    const { container } = render(<QualityWarningBanner metadata={{ keyword: 't' }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('qualityFlags 모두 false면 렌더링 안 함', () => {
+    const { container } = render(
+      <QualityWarningBanner
+        metadata={{
+          qualityFlags: {
+            hasRateLimitFailures: false,
+            hasPartialModules: false,
+            samplingShallow: false,
+          },
+        }}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hasPartialModules true면 배너 표시', () => {
+    render(
+      <QualityWarningBanner
+        metadata={{
+          qualityFlags: {
+            hasRateLimitFailures: true,
+            hasPartialModules: true,
+            samplingShallow: false,
+          },
+          modulesPartial: [
+            { module: 'segmentation', reason: 'rate-limit', chunksTotal: null, chunksFailed: null },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText(/부분 실패했거나 표본이 얕습니다/)).toBeInTheDocument();
+  });
+
+  it('상세 보기 클릭 시 모듈 목록 표시', () => {
+    render(
+      <QualityWarningBanner
+        metadata={{
+          qualityFlags: {
+            hasRateLimitFailures: true,
+            hasPartialModules: true,
+            samplingShallow: false,
+          },
+          modulesPartial: [
+            { module: 'segmentation', reason: 'rate-limit', chunksTotal: null, chunksFailed: null },
+            { module: 'macro-view', reason: 'rate-limit', chunksTotal: null, chunksFailed: null },
+          ],
+          warnings: [],
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '상세 보기' }));
+    expect(screen.getByText(/segmentation/)).toBeInTheDocument();
+    expect(screen.getByText(/macro-view/)).toBeInTheDocument();
+  });
+
+  it('samplingShallow true면 얕은 표본 섹션 표시', () => {
+    render(
+      <QualityWarningBanner
+        metadata={{
+          qualityFlags: {
+            hasRateLimitFailures: false,
+            hasPartialModules: false,
+            samplingShallow: true,
+          },
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '상세 보기' }));
+    expect(screen.getByText(/얕은 표본/)).toBeInTheDocument();
+    expect(screen.getByText(/200건 미만/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/report/quality-warning-banner.tsx
+++ b/apps/web/src/components/report/quality-warning-banner.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState } from 'react';
+
+type ModulePartial = {
+  module: string;
+  reason: 'rate-limit' | 'parse-error' | 'unknown';
+  chunksTotal: number | null;
+  chunksFailed: number | null;
+};
+
+type QualityWarning = {
+  ts: string;
+  phase: string | null;
+  module: string | null;
+  level: 'warn';
+  msg: string;
+};
+
+type QualityFlags = {
+  hasRateLimitFailures: boolean;
+  hasPartialModules: boolean;
+  samplingShallow: boolean;
+};
+
+export type ReportQualityMetadata = {
+  modulesPartial?: ModulePartial[];
+  warnings?: QualityWarning[];
+  qualityFlags?: QualityFlags;
+};
+
+export function QualityWarningBanner(props: { metadata: unknown }) {
+  const [open, setOpen] = useState(false);
+
+  const meta = (props.metadata ?? {}) as ReportQualityMetadata;
+  const flags = meta.qualityFlags;
+  if (!flags) return null;
+  if (!flags.hasPartialModules && !flags.samplingShallow && !flags.hasRateLimitFailures) {
+    return null;
+  }
+
+  const partials = meta.modulesPartial ?? [];
+  const warnings = meta.warnings ?? [];
+
+  const reasonLabel = (r: ModulePartial['reason']) =>
+    r === 'rate-limit' ? 'rate-limit' : r === 'parse-error' ? 'parse-error' : '미분류';
+
+  return (
+    <div
+      className="mx-4 my-3 md:mx-8 rounded-md border border-yellow-500 bg-yellow-50 p-3 text-yellow-900 print:hidden"
+      role="status"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-sm">
+          <span aria-hidden="true">⚠️ </span>이 분석에는 일부 모듈이 부분 실패했거나 표본이
+          얕습니다. 결과 해석 시 주의하세요.
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="text-xs underline shrink-0"
+        >
+          {open ? '닫기' : '상세 보기'}
+        </button>
+      </div>
+
+      {open && (
+        <div className="mt-3 text-sm space-y-3">
+          {partials.length > 0 && (
+            <div>
+              <div className="font-semibold">부분 실패 모듈</div>
+              <ul className="list-disc ml-5 mt-1">
+                {partials.map((m) => (
+                  <li key={m.module}>
+                    {m.module} <span className="text-xs">({reasonLabel(m.reason)})</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {flags.samplingShallow && (
+            <div>
+              <div className="font-semibold">얕은 표본</div>
+              <p className="mt-1">
+                분석에 사용된 articles 또는 comments가 200건 미만입니다. 결과의 일반성에 주의하세요.
+              </p>
+            </div>
+          )}
+
+          {warnings.length > 0 && (
+            <div>
+              <div className="font-semibold">경고 로그</div>
+              <ul className="list-disc ml-5 mt-1 max-h-40 overflow-y-auto">
+                {warnings.map((w, i) => (
+                  <li key={i} className="font-mono text-xs">
+                    [{w.ts}] {w.msg}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/report/report-view.tsx
+++ b/apps/web/src/components/report/report-view.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { FileText } from 'lucide-react';
 import { SectionNav, type Section } from './section-nav';
 import { ReportViewer } from './report-viewer';
+import { QualityWarningBanner } from './quality-warning-banner';
 import { ReportHelp } from './report-help';
 import { PdfExportButton } from '@/components/ui/pdf-export-button';
 import { trpcClient } from '@/lib/trpc';
@@ -154,6 +155,9 @@ export function ReportView({ jobId, fetchFn }: ReportViewProps) {
           <PdfExportButton targetRef={contentRef} filename={`report-job${jobId}`} />
         </div>
       </div>
+
+      {/* Phase 3: 부분 실패/얕은 표본 가시화 */}
+      <QualityWarningBanner metadata={report.metadata} />
 
       {/* 본문: 섹션 네비 + 마크다운 뷰어 */}
       <div className="flex flex-col md:flex-row" ref={contentRef}>

--- a/packages/core/src/analysis/quality-metadata.ts
+++ b/packages/core/src/analysis/quality-metadata.ts
@@ -1,0 +1,127 @@
+// analysis_reports.metadata에 부분 실패/경고 정보를 채우는 빌더.
+// 보고서 markdown에 footer를 append하는 헬퍼도 함께.
+//
+// 출처:
+//   - collection_jobs.progress._events (level === 'warn')
+//   - collection_jobs.progress.sampling.{articles,comments}.totalSampled
+//
+// schema 변경 없음 — analysis_reports.metadata는 jsonb.
+
+const SAMPLING_SHALLOW_THRESHOLD = 200;
+const CHUNK_FAILURE_RE = /^([\w-]+) 청크 분석 실패.*Last error: (.+?)\.?$/;
+
+export type ModulePartial = {
+  module: string;
+  reason: 'rate-limit' | 'parse-error' | 'unknown';
+  chunksTotal: number | null;
+  chunksFailed: number | null;
+};
+
+export type QualityWarning = {
+  ts: string;
+  phase: string | null;
+  module: string | null;
+  level: 'warn';
+  msg: string;
+};
+
+export type QualityFlags = {
+  hasRateLimitFailures: boolean;
+  hasPartialModules: boolean;
+  samplingShallow: boolean;
+};
+
+export type QualityMetadata = {
+  modulesPartial: ModulePartial[];
+  warnings: QualityWarning[];
+  qualityFlags: QualityFlags;
+};
+
+type ProgressEvent = { ts: string; level: string; msg: string };
+
+export function buildQualityMetadata(
+  progress: Record<string, unknown> | null | undefined,
+): QualityMetadata {
+  const events = (progress?._events as ProgressEvent[] | undefined) ?? [];
+  const warns = events.filter((e) => e.level === 'warn');
+
+  const modulesPartial: ModulePartial[] = [];
+  const seen = new Set<string>();
+  for (const w of warns) {
+    const m = w.msg.match(CHUNK_FAILURE_RE);
+    if (!m) continue;
+    const [, mod, lastErr] = m;
+    if (seen.has(mod)) continue;
+    seen.add(mod);
+    const reason: ModulePartial['reason'] = /capacity|exhausted|quota/i.test(lastErr)
+      ? 'rate-limit'
+      : /parse|json/i.test(lastErr)
+        ? 'parse-error'
+        : 'unknown';
+    modulesPartial.push({ module: mod, reason, chunksTotal: null, chunksFailed: null });
+  }
+
+  const warnings: QualityWarning[] = warns.map((w) => {
+    const m = w.msg.match(CHUNK_FAILURE_RE);
+    return {
+      ts: w.ts,
+      phase: m ? 'analysis' : null,
+      module: m?.[1] ?? null,
+      level: 'warn',
+      msg: w.msg,
+    };
+  });
+
+  const sampling = progress?.sampling as
+    | {
+        articles?: { totalSampled?: number };
+        comments?: { totalSampled?: number };
+      }
+    | undefined;
+  const articlesShallow =
+    (sampling?.articles?.totalSampled ?? Infinity) < SAMPLING_SHALLOW_THRESHOLD;
+  const commentsShallow =
+    (sampling?.comments?.totalSampled ?? Infinity) < SAMPLING_SHALLOW_THRESHOLD;
+
+  const qualityFlags: QualityFlags = {
+    hasRateLimitFailures: modulesPartial.some((m) => m.reason === 'rate-limit'),
+    hasPartialModules: modulesPartial.length > 0,
+    samplingShallow: articlesShallow || commentsShallow,
+  };
+
+  return { modulesPartial, warnings, qualityFlags };
+}
+
+export function appendQualityFooterToMarkdown(markdown: string, meta: QualityMetadata): string {
+  const f = meta.qualityFlags;
+  if (!f.hasPartialModules && !f.samplingShallow && !f.hasRateLimitFailures) {
+    return markdown;
+  }
+
+  const lines: string[] = [
+    '',
+    '---',
+    '',
+    '## ⚠️ 분석 경고',
+    '',
+    '이 보고서에는 다음 경고가 포함됩니다:',
+    '',
+  ];
+  if (meta.modulesPartial.length > 0) {
+    const mods = meta.modulesPartial.map((m) => m.module).join(', ');
+    const reason = meta.modulesPartial.every((m) => m.reason === 'rate-limit')
+      ? 'rate-limit으로 일부 청크 분석 누락'
+      : '일부 청크 분석 실패';
+    lines.push(`- **부분 실패 모듈**: ${mods} (${reason})`);
+  }
+  if (f.samplingShallow) {
+    lines.push(
+      `- **얕은 표본**: 분석 입력 중 articles 또는 comments 표본이 ${SAMPLING_SHALLOW_THRESHOLD}건 미만입니다.`,
+    );
+  }
+  lines.push(
+    '',
+    '자세한 경고 로그는 모니터 페이지의 "분석 경고" 또는 잡 상세의 progress._events를 확인하세요.',
+  );
+  return markdown.trimEnd() + '\n' + lines.join('\n') + '\n';
+}

--- a/packages/core/src/db/schema/analysis.ts
+++ b/packages/core/src/db/schema/analysis.ts
@@ -49,6 +49,25 @@ export const analysisReports = pgTable(
       totalTokens: number;
       reportModel?: { provider: string; model: string };
       generatedAt: string;
+      // Phase 3 신규 필드 — quality-metadata 빌더가 채움 (선택적: fallback 리포트에는 없을 수 있음)
+      modulesPartial?: Array<{
+        module: string;
+        reason: 'rate-limit' | 'parse-error' | 'unknown';
+        chunksTotal: number | null;
+        chunksFailed: number | null;
+      }>;
+      warnings?: Array<{
+        ts: string;
+        phase: string | null;
+        module: string | null;
+        level: 'warn';
+        msg: string;
+      }>;
+      qualityFlags?: {
+        hasRateLimitFailures: boolean;
+        hasPartialModules: boolean;
+        samplingShallow: boolean;
+      };
     }>(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
   },

--- a/packages/core/src/report/generator.ts
+++ b/packages/core/src/report/generator.ts
@@ -1,7 +1,11 @@
 // 통합 리포트 마크다운 생성기 (D-04 2단계)
 import { analyzeText } from '@krdn/ai-analysis-kit/gateway';
+import { eq } from 'drizzle-orm';
 import { persistAnalysisReport } from '../analysis/persist-analysis';
 import { getModuleModelConfig } from '../analysis/model-config';
+import { buildQualityMetadata, appendQualityFooterToMarkdown } from '../analysis/quality-metadata';
+import { getDb } from '../db';
+import { collectionJobs } from '../db/schema/collections';
 import type { ReportGenerationInput } from '../types/report';
 import type { AnalysisDomain } from '../analysis/domain';
 import { getDomainConfig, getSupportedDomains } from '../analysis/domain';
@@ -116,11 +120,27 @@ ${resultsJson}
   const reportTokens = (result.usage as any)?.totalTokens ?? 0;
   const totalTokens = moduleTokens + reportTokens;
 
+  // Phase 3: 부분 실패·얕은 표본 신호를 metadata + footer에 노출
+  //          (job 271 사례 — completed인데 부분 실패 가시성 부재 결함 수정)
+  let qualityMeta;
+  try {
+    const [jobRow] = await getDb()
+      .select({ progress: collectionJobs.progress })
+      .from(collectionJobs)
+      .where(eq(collectionJobs.id, input.jobId))
+      .limit(1);
+    qualityMeta = buildQualityMetadata(jobRow?.progress as Record<string, unknown> | null);
+  } catch {
+    // progress 조회 실패는 보고서 생성을 막지 않음
+    qualityMeta = buildQualityMetadata(null);
+  }
+  const finalMarkdown = appendQualityFooterToMarkdown(markdownContent, qualityMeta);
+
   // DB에 리포트 저장
   await persistAnalysisReport({
     jobId: input.jobId,
     title: `${input.keyword} 종합 분석 리포트`,
-    markdownContent,
+    markdownContent: finalMarkdown,
     oneLiner,
     metadata: {
       keyword: input.keyword,
@@ -133,8 +153,12 @@ ${resultsJson}
       totalTokens,
       reportModel: { provider: config.provider, model: config.model },
       generatedAt: new Date().toISOString(),
+      // === Phase 3 신규 필드 ===
+      modulesPartial: qualityMeta.modulesPartial,
+      warnings: qualityMeta.warnings,
+      qualityFlags: qualityMeta.qualityFlags,
     },
   });
 
-  return { markdownContent, oneLiner, totalTokens };
+  return { markdownContent: finalMarkdown, oneLiner, totalTokens };
 }

--- a/packages/core/tests/quality-metadata.test.ts
+++ b/packages/core/tests/quality-metadata.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildQualityMetadata,
+  appendQualityFooterToMarkdown,
+} from '../src/analysis/quality-metadata';
+
+describe('buildQualityMetadata', () => {
+  it('rate-limit warn 2건 + sampling 130 → 모든 flag true', () => {
+    const progress = {
+      _events: [
+        {
+          ts: '2026-04-26T04:44:36Z',
+          level: 'warn',
+          msg: 'segmentation 청크 분석 실패 (계속 진행): Failed after 3 attempts. Last error: You have exhausted your capacity on this model. Your quota will reset after 0s.',
+        },
+        {
+          ts: '2026-04-26T04:45:27Z',
+          level: 'warn',
+          msg: 'macro-view 청크 분석 실패 (계속 진행): Failed after 3 attempts. Last error: You have exhausted your capacity.',
+        },
+      ],
+      sampling: {
+        articles: { totalSampled: 130 },
+        comments: { totalSampled: 200 },
+      },
+    };
+    const m = buildQualityMetadata(progress);
+    expect(m.qualityFlags.hasRateLimitFailures).toBe(true);
+    expect(m.qualityFlags.hasPartialModules).toBe(true);
+    expect(m.qualityFlags.samplingShallow).toBe(true); // articles 130 < 200
+    expect(m.modulesPartial).toHaveLength(2);
+    expect(m.modulesPartial[0].module).toBe('segmentation');
+    expect(m.modulesPartial[0].reason).toBe('rate-limit');
+    expect(m.warnings).toHaveLength(2);
+    expect(m.warnings[0].phase).toBe('analysis');
+    expect(m.warnings[0].module).toBe('segmentation');
+  });
+
+  it('parse-error reason 분류', () => {
+    const progress = {
+      _events: [
+        {
+          ts: 't',
+          level: 'warn',
+          msg: 'final-summary 청크 분석 실패 (계속 진행): Failed after 3 attempts. Last error: Failed to parse JSON response.',
+        },
+      ],
+    };
+    const m = buildQualityMetadata(progress);
+    expect(m.modulesPartial[0].reason).toBe('parse-error');
+    expect(m.qualityFlags.hasRateLimitFailures).toBe(false);
+    expect(m.qualityFlags.hasPartialModules).toBe(true);
+  });
+
+  it('빈 progress → 모든 flag false', () => {
+    const m = buildQualityMetadata({});
+    expect(m.qualityFlags.hasRateLimitFailures).toBe(false);
+    expect(m.qualityFlags.hasPartialModules).toBe(false);
+    expect(m.qualityFlags.samplingShallow).toBe(false);
+    expect(m.modulesPartial).toHaveLength(0);
+    expect(m.warnings).toHaveLength(0);
+  });
+
+  it('null progress → 모든 flag false', () => {
+    const m = buildQualityMetadata(null);
+    expect(m.qualityFlags.hasPartialModules).toBe(false);
+  });
+
+  it('동일 모듈 중복 warn은 modulesPartial에서 1회만', () => {
+    const progress = {
+      _events: [
+        {
+          ts: 't1',
+          level: 'warn',
+          msg: 'segmentation 청크 분석 실패 (계속 진행): Failed after 3 attempts. Last error: exhausted.',
+        },
+        {
+          ts: 't2',
+          level: 'warn',
+          msg: 'segmentation 청크 분석 실패 (계속 진행): Failed after 3 attempts. Last error: exhausted.',
+        },
+      ],
+    };
+    const m = buildQualityMetadata(progress);
+    expect(m.modulesPartial).toHaveLength(1);
+    expect(m.warnings).toHaveLength(2); // warnings는 모두 보존
+  });
+
+  it('chunk failure 패턴이 아닌 warn은 modulesPartial 미포함', () => {
+    const progress = {
+      _events: [{ ts: 't', level: 'warn', msg: 'macro-view dailyMentionTrend: AI가 빈 배열 반환' }],
+    };
+    const m = buildQualityMetadata(progress);
+    expect(m.modulesPartial).toHaveLength(0);
+    expect(m.warnings).toHaveLength(1);
+    expect(m.warnings[0].module).toBeNull();
+    expect(m.warnings[0].phase).toBeNull();
+  });
+
+  it('comments totalSampled < 200이어도 samplingShallow=true', () => {
+    const progress = {
+      sampling: {
+        articles: { totalSampled: 300 },
+        comments: { totalSampled: 100 },
+      },
+    };
+    const m = buildQualityMetadata(progress);
+    expect(m.qualityFlags.samplingShallow).toBe(true);
+  });
+});
+
+describe('appendQualityFooterToMarkdown', () => {
+  const baseMeta = {
+    modulesPartial: [],
+    warnings: [],
+    qualityFlags: {
+      hasRateLimitFailures: false,
+      hasPartialModules: false,
+      samplingShallow: false,
+    },
+  } as const;
+
+  it('flags 모두 false → footer 없음', () => {
+    const out = appendQualityFooterToMarkdown('# 본문', baseMeta);
+    expect(out).toBe('# 본문');
+  });
+
+  it('hasPartialModules true → footer 포함', () => {
+    const meta = {
+      modulesPartial: [
+        {
+          module: 'segmentation',
+          reason: 'rate-limit' as const,
+          chunksTotal: null,
+          chunksFailed: null,
+        },
+        {
+          module: 'macro-view',
+          reason: 'rate-limit' as const,
+          chunksTotal: null,
+          chunksFailed: null,
+        },
+      ],
+      warnings: [],
+      qualityFlags: { hasRateLimitFailures: true, hasPartialModules: true, samplingShallow: false },
+    };
+    const out = appendQualityFooterToMarkdown('# 본문', meta);
+    expect(out).toContain('## ⚠️ 분석 경고');
+    expect(out).toContain('segmentation, macro-view');
+    expect(out).toContain('rate-limit으로 일부 청크 분석 누락');
+  });
+
+  it('samplingShallow만 true → 얕은 표본 항목 포함', () => {
+    const meta = {
+      ...baseMeta,
+      qualityFlags: { ...baseMeta.qualityFlags, samplingShallow: true },
+    };
+    const out = appendQualityFooterToMarkdown('# 본문', meta);
+    expect(out).toContain('얕은 표본');
+    expect(out).toContain('200건 미만');
+  });
+
+  it('mixed reason → 일반 사유 문구', () => {
+    const meta = {
+      modulesPartial: [
+        {
+          module: 'segmentation',
+          reason: 'rate-limit' as const,
+          chunksTotal: null,
+          chunksFailed: null,
+        },
+        {
+          module: 'final-summary',
+          reason: 'parse-error' as const,
+          chunksTotal: null,
+          chunksFailed: null,
+        },
+      ],
+      warnings: [],
+      qualityFlags: { hasRateLimitFailures: true, hasPartialModules: true, samplingShallow: false },
+    };
+    const out = appendQualityFooterToMarkdown('# 본문', meta);
+    expect(out).toContain('일부 청크 분석 실패');
+    expect(out).not.toContain('rate-limit으로 일부 청크 분석 누락');
+  });
+});

--- a/packages/core/tests/report-generator-quality.test.ts
+++ b/packages/core/tests/report-generator-quality.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateIntegratedReport } from '../src/report/generator';
+import { persistAnalysisReport } from '../src/analysis/persist-analysis';
+
+// AI Gateway mock
+vi.mock('@krdn/ai-analysis-kit/gateway', () => ({
+  analyzeText: vi.fn().mockResolvedValue({
+    text: '# 분석 보고서\n\n본문 내용',
+    usage: { totalTokens: 1000 },
+  }),
+}));
+
+// persistAnalysisReport mock
+vi.mock('../src/analysis/persist-analysis', () => ({
+  persistAnalysisReport: vi.fn().mockResolvedValue({ id: 999 }),
+  persistAnalysisResult: vi.fn().mockResolvedValue({ id: 1 }),
+}));
+
+// model-config mock
+vi.mock('../src/analysis/model-config', () => ({
+  getModuleModelConfig: vi.fn().mockResolvedValue({
+    provider: 'gemini',
+    model: 'gemini-2.5-flash',
+    baseUrl: '',
+    apiKey: 'test-key',
+  }),
+}));
+
+// DB mock — getDb().select().from().where().limit() 체인
+vi.mock('../src/db', () => ({
+  getDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () =>
+            Promise.resolve([
+              {
+                progress: {
+                  _events: [
+                    {
+                      ts: '2026-04-26T04:44:36Z',
+                      level: 'warn',
+                      msg: 'segmentation 청크 분석 실패 (계속 진행): Failed after 3 attempts. Last error: You have exhausted your capacity.',
+                    },
+                  ],
+                  sampling: {
+                    articles: { totalSampled: 130 },
+                    comments: { totalSampled: 200 },
+                  },
+                },
+              },
+            ]),
+        }),
+      }),
+    }),
+  }),
+}));
+
+// domain config mock
+vi.mock('../src/analysis/domain', () => ({
+  getDomainConfig: () => ({
+    displayName: '정치 여론',
+    reportSystemPrompt: '정치 여론 분석 시스템 프롬프트',
+    reportSectionTemplate: '\n1. 핵심 요약\n2. 세부 분석\n3. 전략 제언',
+    stage4: { parallel: [], sequential: [] },
+  }),
+  getSupportedDomains: () => ['political'],
+}));
+
+// generateIntegratedReport — quality metadata 통합 smoke test
+// 외부 LLM / DB 의존성을 모두 mock하여 footer 삽입 + metadata 필드 전달 여부만 검증.
+describe('generateIntegratedReport — quality metadata 통합', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('progress._events에 rate-limit warn → markdown footer + metadata.qualityFlags 포함', async () => {
+    const result = await generateIntegratedReport({
+      jobId: 271,
+      keyword: '한동훈',
+      dateRange: { start: new Date('2026-04-19'), end: new Date('2026-04-26') },
+      results: {
+        'final-summary': {
+          module: 'final-summary',
+          status: 'completed',
+          result: { oneLiner: '한 줄 요약 테스트' },
+          usage: {
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 150,
+            provider: 'gemini',
+            model: 'gemini-2.5-flash',
+          },
+        },
+      },
+      completedModules: ['final-summary'],
+      failedModules: [],
+    } as never);
+
+    // 반환된 markdown에 footer가 포함되어야 함
+    expect(result.markdownContent).toContain('## ⚠️ 분석 경고');
+    expect(result.markdownContent).toContain('segmentation');
+    expect(result.markdownContent).toContain('rate-limit으로 일부 청크 분석 누락');
+    // 얕은 표본도 포함 (articles 130 < 200)
+    expect(result.markdownContent).toContain('얕은 표본');
+
+    // persistAnalysisReport에 신규 metadata 필드가 전달되어야 함
+    const saveCall = (persistAnalysisReport as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(saveCall.markdownContent).toContain('## ⚠️ 분석 경고');
+    expect(saveCall.metadata.qualityFlags.hasPartialModules).toBe(true);
+    expect(saveCall.metadata.qualityFlags.hasRateLimitFailures).toBe(true);
+    expect(saveCall.metadata.qualityFlags.samplingShallow).toBe(true);
+    expect(saveCall.metadata.modulesPartial).toHaveLength(1);
+    expect(saveCall.metadata.modulesPartial[0].module).toBe('segmentation');
+    expect(saveCall.metadata.warnings).toHaveLength(1);
+  });
+
+  it('보고서 생성 후 markdownContent가 string으로 반환됨', async () => {
+    const result = await generateIntegratedReport({
+      jobId: 271,
+      keyword: '기본케이스',
+      dateRange: { start: new Date('2026-04-01'), end: new Date('2026-04-26') },
+      results: {
+        'final-summary': {
+          module: 'final-summary',
+          status: 'completed',
+          result: { oneLiner: '요약' },
+          usage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            totalTokens: 15,
+            provider: 'gemini',
+            model: 'gemini-2.5-flash',
+          },
+        },
+      },
+      completedModules: ['final-summary'],
+      failedModules: [],
+    } as never);
+
+    expect(result.markdownContent).toBeDefined();
+    expect(typeof result.markdownContent).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary
\"completed인데 부분 실패\" 분석 잡(예: 271)의 가시성 결함 수정.

- \`buildQualityMetadata(progress)\` + \`appendQualityFooterToMarkdown(md, meta)\` 신규 헬퍼 — progress._events의 청크 실패 warn에서 modulesPartial/warnings/qualityFlags 추출.
- \`generateIntegratedReport\`이 collection_jobs.progress 조회 → quality metadata + markdown footer 자동 첨부 → \`analysis_reports.metadata\`에 신규 필드 3개(modulesPartial/warnings/qualityFlags) 저장.
- \`<QualityWarningBanner>\` 신규 — 보고서 페이지(\`report-view.tsx\`)에 노란 배너 + 상세 보기 토글.
- 구버전 보고서(qualityFlags 없는)는 배너 미표시 (graceful fallback).
- schema 변경 없음(jsonb metadata 활용). \$type 확장만.

## 의존성
독립. PR1~PR4와 병렬 머지 가능. main 기준 분기.

## Files
- \`packages/core/src/analysis/quality-metadata.ts\` (신규)
- \`packages/core/src/report/generator.ts\` (수정)
- \`packages/core/src/db/schema/analysis.ts\` (수정 — \$type 확장)
- \`packages/core/tests/quality-metadata.test.ts\` (신규, 11 케이스)
- \`packages/core/tests/report-generator-quality.test.ts\` (신규, 2 smoke 케이스)
- \`apps/web/src/components/report/quality-warning-banner.tsx\` (신규)
- \`apps/web/src/components/report/report-view.tsx\` (수정)
- \`apps/web/src/__tests__/quality-warning-banner.test.tsx\` (신규, 6 케이스)

## Spec
Section 5 (Phase 3) of design doc.

## Test plan
- [x] core: quality-metadata 11 + report-generator-quality 2 = passing
- [x] web: QualityWarningBanner 6 cases passing
- [x] 회귀: 전체 통과
- [x] 보고서 페이지에 \`<QualityWarningBanner>\` 배너 노출 (수동 검증은 Task 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)