### PR TITLE
fix(core): Phase 3 회귀 — fallback report quality metadata + jsonb merge

### DIFF
--- a/packages/core/src/analysis/persist-analysis.ts
+++ b/packages/core/src/analysis/persist-analysis.ts
@@ -75,7 +75,11 @@ export async function persistAnalysisResult(data: typeof analysisResults.$inferI
 
 /**
  * 종합 분석 리포트 upsert (jobId 기준)
- * 기존 리포트가 있으면 갱신, 없으면 삽입
+ * 기존 리포트가 있으면 갱신, 없으면 삽입.
+ *
+ * metadata는 jsonb merge(`||`)로 갱신해 호출자가 부분 metadata를 보내도
+ * 기존에 있던 다른 키(예: qualityFlags/modulesPartial — Phase 3 신호)가 사라지지 않게 한다.
+ * 같은 키는 우측(excluded) 우선이라 의도된 갱신은 그대로 적용된다.
  */
 export async function persistAnalysisReport(data: typeof analysisReports.$inferInsert) {
   const [report] = await getDb()
@@ -87,7 +91,7 @@ export async function persistAnalysisReport(data: typeof analysisReports.$inferI
         title: sql`excluded.title`,
         markdownContent: sql`excluded.markdown_content`,
         oneLiner: sql`excluded.one_liner`,
-        metadata: sql`excluded.metadata`,
+        metadata: sql`COALESCE(${analysisReports.metadata}, '{}'::jsonb) || COALESCE(excluded.metadata, '{}'::jsonb)`,
       },
     })
     .returning();

--- a/packages/core/src/analysis/report-builder.ts
+++ b/packages/core/src/analysis/report-builder.ts
@@ -1,7 +1,11 @@
 // 파이프라인 리포트 생성 — 조기 종료/정상 종료 시 리포트 빌드
+import { eq } from 'drizzle-orm';
+import { getDb } from '../db';
+import { collectionJobs } from '../db/schema/collections';
 import { generateIntegratedReport } from '../report/generator';
 import { updateJobProgress } from '../pipeline/persist';
 import { persistAnalysisReport } from './persist-analysis';
+import { buildQualityMetadata, appendQualityFooterToMarkdown } from './quality-metadata';
 import type { AnalysisModuleResult, AnalysisInput } from './types';
 
 /** 조기 종료 시 결과 빌드 헬퍼 (취소/비용 한도 초과) */
@@ -110,10 +114,25 @@ async function saveFallbackReport(
   failedModules: string[],
 ) {
   try {
+    // Phase 3: fallback 경로에서도 progress._events에서 부분 실패/얕은 표본 신호를 추출해
+    //          metadata + markdown footer에 반영. (정상 보고서 경로의 generator.ts와 동일 정책)
+    let qualityMeta;
+    try {
+      const [jobRow] = await getDb()
+        .select({ progress: collectionJobs.progress })
+        .from(collectionJobs)
+        .where(eq(collectionJobs.id, input.jobId))
+        .limit(1);
+      qualityMeta = buildQualityMetadata(jobRow?.progress as Record<string, unknown> | null);
+    } catch {
+      qualityMeta = buildQualityMetadata(null);
+    }
+    const finalMarkdown = appendQualityFooterToMarkdown(markdownContent, qualityMeta);
+
     await persistAnalysisReport({
       jobId: input.jobId,
       title: `${input.keyword} 종합 분석 리포트`,
-      markdownContent,
+      markdownContent: finalMarkdown,
       oneLiner,
       metadata: {
         keyword: input.keyword,
@@ -125,6 +144,9 @@ async function saveFallbackReport(
         modulesFailed: failedModules,
         totalTokens: 0,
         generatedAt: new Date().toISOString(),
+        modulesPartial: qualityMeta.modulesPartial,
+        warnings: qualityMeta.warnings,
+        qualityFlags: qualityMeta.qualityFlags,
       },
     });
   } catch (e) {

--- a/packages/core/tests/report-builder-fallback-quality.test.ts
+++ b/packages/core/tests/report-builder-fallback-quality.test.ts
@@ -1,0 +1,144 @@
+/* eslint-disable import-x/order */
+/**
+ * fallback 보고서 경로(buildResult → saveFallbackReport)에서도 Phase 3 quality metadata + footer가
+ * 적용되는지 검증. 정상 보고서 경로(generator.ts)는 report-generator-quality.test.ts가 검증.
+ *
+ * vi.mock 호이스팅 때문에 import-x/order 규칙을 비활성화 — vi.hoisted/vi.mock 호출이
+ * imports 사이에 끼어들어야 하는 vitest 패턴.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { persistMock, progressMock } = vi.hoisted(() => ({
+  persistMock: vi.fn().mockResolvedValue({ id: 1 }),
+  progressMock: vi.fn(),
+}));
+
+vi.mock('playwright', () => ({
+  chromium: { launch: vi.fn() },
+}));
+
+vi.mock('@krdn/ai-analysis-kit/gateway', () => ({
+  analyzeText: vi.fn(),
+  analyzeStructured: vi.fn(),
+}));
+
+// generateIntegratedReport mock — buildResult가 try → catch fallback 흐름을 타도록 강제 throw
+vi.mock('../src/report/generator', () => ({
+  generateIntegratedReport: vi.fn().mockRejectedValue(new Error('LLM 호출 실패')),
+}));
+
+vi.mock('../src/pipeline/persist', () => ({
+  updateJobProgress: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../src/analysis/persist-analysis', () => ({
+  persistAnalysisReport: persistMock,
+}));
+
+vi.mock('../src/db', () => ({
+  getDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => progressMock(),
+        }),
+      }),
+    }),
+  }),
+}));
+import { buildResult } from '../src/analysis/report-builder';
+import type { AnalysisInput, AnalysisModuleResult } from '../src/analysis/types';
+
+const baseInput: AnalysisInput = {
+  jobId: 999,
+  keyword: '한동훈',
+  articles: [],
+  videos: [],
+  comments: [],
+  dateRange: {
+    start: new Date('2026-04-19T00:00:00Z'),
+    end: new Date('2026-04-26T00:00:00Z'),
+  },
+  domain: 'political',
+};
+
+const completedResult: AnalysisModuleResult = {
+  module: 'segmentation',
+  status: 'completed',
+  result: { ok: true },
+};
+
+describe('saveFallbackReport — Phase 3 quality metadata 통합', () => {
+  beforeEach(() => {
+    persistMock.mockClear();
+    progressMock.mockReset();
+  });
+
+  it('progress._events에 청크 실패 warn이 있으면 metadata에 modulesPartial/qualityFlags + footer', async () => {
+    progressMock.mockResolvedValue([
+      {
+        progress: {
+          _events: [
+            {
+              ts: '2026-04-26T15:10:00Z',
+              level: 'warn',
+              msg: 'segmentation 청크 분석 실패 (계속 진행): Failed after 3 attempts. Last error: You have exhausted your capacity on this model. Your quota will reset after 0s.',
+            },
+          ],
+          sampling: {
+            articles: { totalSampled: 230 },
+            comments: { totalSampled: 401 },
+          },
+        },
+      },
+    ]);
+
+    await buildResult(
+      { segmentation: completedResult },
+      true, // cancelledByUser → fallback 경로 진입
+      false,
+      baseInput,
+    );
+
+    expect(persistMock).toHaveBeenCalledTimes(1);
+    const arg = persistMock.mock.calls[0][0];
+    expect(arg.metadata.qualityFlags).toBeDefined();
+    expect(arg.metadata.qualityFlags.hasRateLimitFailures).toBe(true);
+    expect(arg.metadata.qualityFlags.hasPartialModules).toBe(true);
+    expect(arg.metadata.modulesPartial).toHaveLength(1);
+    expect(arg.metadata.modulesPartial[0].module).toBe('segmentation');
+    expect(arg.metadata.warnings).toHaveLength(1);
+    // markdown footer 자동 첨부
+    expect(arg.markdownContent).toContain('## ⚠️ 분석 경고');
+    expect(arg.markdownContent).toContain('segmentation');
+  });
+
+  it('progress가 비어 있어도 qualityFlags 키는 포함됨 (모두 false)', async () => {
+    progressMock.mockResolvedValue([{ progress: {} }]);
+
+    await buildResult({ segmentation: completedResult }, true, false, baseInput);
+
+    expect(persistMock).toHaveBeenCalledTimes(1);
+    const arg = persistMock.mock.calls[0][0];
+    expect(arg.metadata.qualityFlags).toEqual({
+      hasRateLimitFailures: false,
+      hasPartialModules: false,
+      samplingShallow: false,
+    });
+    expect(arg.metadata.modulesPartial).toEqual([]);
+    expect(arg.metadata.warnings).toEqual([]);
+    // flags 모두 false → footer 미첨부
+    expect(arg.markdownContent).not.toContain('⚠️ 분석 경고');
+  });
+
+  it('progress 조회 실패 시에도 graceful fallback (qualityFlags 비어 있는 채로)', async () => {
+    progressMock.mockRejectedValue(new Error('DB 일시 장애'));
+
+    await buildResult({ segmentation: completedResult }, true, false, baseInput);
+
+    expect(persistMock).toHaveBeenCalledTimes(1);
+    const arg = persistMock.mock.calls[0][0];
+    expect(arg.metadata.qualityFlags).toBeDefined();
+    expect(arg.metadata.qualityFlags.hasPartialModules).toBe(false);
+  });
+});


### PR DESCRIPTION
## 배경
[Job 274](http://192.168.0.5:3300) 검증 중 회귀 발견:
- partial_failure 잡(macro-view 단일 모듈 실패 + 청크 11건 rate-limit)이 보고서 페이지에서 부분 실패 신호를 노출하지 못함.
- \`analysis_reports.metadata\`에 \`qualityFlags\`/\`modulesPartial\`/\`warnings\` 키 자체 부재.
- markdown footer도 누락.

## 원인 (가설)
- 정상 경로(\`generator.ts\`)는 신규 metadata 필드를 채우지만, 어떤 후속 코드가 \`persistAnalysisReport\`를 다시 호출해 옛 형태 metadata로 덮어쓰는 것으로 추정.
- \`saveFallbackReport\` 경로는 PR130(Phase 3) 당시 통합되지 않아 fallback 시점에 신호 손실.

## 방어적 수정
1. **saveFallbackReport에 buildQualityMetadata 통합** — fallback 경로에서도 \`progress._events\`를 읽어 metadata 신규 필드 채우고 \`appendQualityFooterToMarkdown\`으로 footer 자동 첨부.
2. **persistAnalysisReport metadata jsonb merge** — \`onConflictDoUpdate\` 시 metadata를 \`COALESCE(existing, '{}') || COALESCE(excluded, '{}')\`로 갱신. 호출자가 부분 metadata 보내도 기존 키(qualityFlags 등) 보존. 같은 키는 우측(excluded) 우선이라 의도된 갱신은 그대로 적용.

## Files
- \`packages/core/src/analysis/persist-analysis.ts\` (수정)
- \`packages/core/src/analysis/report-builder.ts\` (수정)
- \`packages/core/tests/report-builder-fallback-quality.test.ts\` (신규, 3 케이스)

## Test plan
- [x] vitest: fallback quality 3 cases passing
- [x] 회귀: 358 passed (3 신규 추가)
- [x] lint, build 통과
- [ ] 운영 배포 후 신규 잡으로 metadata 채워짐 검증

## ⚠️ 주의
배포 후 첫 partial_failure 잡에서 \`analysis_reports.metadata.qualityFlags\` 키 존재를 확인해야 fix가 실효를 거뒀는지 알 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)