### PR TITLE
feat: 모듈별 maxOutputTokens DB 노출 (#133)

### DIFF
--- a/apps/web/src/server/trpc/routers/settings.ts
+++ b/apps/web/src/server/trpc/routers/settings.ts
@@ -45,10 +45,16 @@ export const settingsRouter = router({
         moduleName: z.string().min(1),
         provider: aiProviderEnum,
         model: z.string().min(1),
+        maxOutputTokens: z.number().int().min(512).max(65536).nullable().optional(),
       }),
     )
     .mutation(async ({ input }) => {
-      return upsertModelSetting(input.moduleName, input.provider, input.model);
+      return upsertModelSetting(
+        input.moduleName,
+        input.provider,
+        input.model,
+        input.maxOutputTokens ?? null,
+      );
     }),
 
   // 프리셋별 모듈 모델 설정 저장 (시스템 관리자 전용)
@@ -59,6 +65,7 @@ export const settingsRouter = router({
         moduleName: z.string().min(1),
         provider: aiProviderEnum,
         model: z.string().min(1),
+        maxOutputTokens: z.number().int().min(512).max(65536).nullable().optional(),
       }),
     )
     .mutation(async ({ input }) => {
@@ -67,6 +74,7 @@ export const settingsRouter = router({
         input.moduleName,
         input.provider,
         input.model,
+        input.maxOutputTokens ?? null,
       );
     }),
 

--- a/packages/core/scripts/rerun-macro-view.ts
+++ b/packages/core/scripts/rerun-macro-view.ts
@@ -1,0 +1,68 @@
+/**
+ * 단일 모듈 재실행 — Job N의 macro-view만 다시 돌려 결과를 analysis_results에 UPSERT.
+ *
+ * 사용:
+ *   cd packages/core
+ *   set -a; source ../../apps/web/.env.local; set +a
+ *   AIS_MODULE_CACHE=off pnpm exec tsx scripts/rerun-macro-view.ts <jobId>
+ */
+import { eq } from 'drizzle-orm';
+import { getDb } from '../src/db';
+import { collectionJobs } from '../src/db/schema';
+import {
+  loadAnalysisInput,
+  loadAnalysisInputViaCollector,
+  shouldUseCollectorLoader,
+} from '../src/analysis/data-loader';
+import { runModule } from '../src/analysis/runner';
+import { macroViewModule } from '../src/analysis/modules/macro-view';
+
+async function main() {
+  const jobIdArg = process.argv[2];
+  if (!jobIdArg) {
+    console.error('usage: rerun-macro-view.ts <jobId>');
+    process.exit(2);
+  }
+  const jobId = Number(jobIdArg);
+  if (!Number.isFinite(jobId)) {
+    console.error('jobId must be numeric');
+    process.exit(2);
+  }
+
+  const db = getDb();
+  const [job] = await db.select().from(collectionJobs).where(eq(collectionJobs.id, jobId)).limit(1);
+  if (!job) {
+    console.error(`job ${jobId} not found`);
+    process.exit(1);
+  }
+  console.log(`[rerun] job=${jobId} keyword=${job.keyword} status=${job.status}`);
+
+  const jobOptions = (job.options as Record<string, unknown>) || {};
+  const isCollectorPath = Boolean(jobOptions.useCollectorLoader) || shouldUseCollectorLoader();
+  console.log(`[rerun] loader=${isCollectorPath ? 'collector' : 'legacy'}`);
+
+  const loadResult = isCollectorPath
+    ? await loadAnalysisInputViaCollector(jobId)
+    : await loadAnalysisInput(jobId);
+  const input = loadResult.input;
+  console.log(
+    `[rerun] input articles=${input.articles.length} videos=${input.videos.length} comments=${input.comments.length}`,
+  );
+
+  const result = await runModule(macroViewModule, input);
+  console.log(`[rerun] result status=${result.status}`);
+  if (result.status === 'failed') {
+    console.error(`[rerun] error: ${result.errorMessage}`);
+    process.exit(1);
+  }
+  if (result.usage) {
+    console.log(
+      `[rerun] usage input=${result.usage.inputTokens} output=${result.usage.outputTokens} total=${result.usage.totalTokens}`,
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error('[rerun] fatal:', err);
+  process.exit(1);
+});

--- a/packages/core/src/analysis/__tests__/model-config.maxOutputTokens.test.ts
+++ b/packages/core/src/analysis/__tests__/model-config.maxOutputTokens.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getModuleModelConfigForPreset } from '../model-config';
+import { createModelConfigAdapter } from '../runner';
+
+// --- runner.ts import-time side-effect mocks ---
+// runner.ts(=테스트 대상)가 다음 모듈을 import만 해도 DB pool / Redis / kit provider registry가 초기화되어
+// 단위 테스트 환경에서 실패한다. 아래 vi.mock은 모두 import 시점 부수효과를 차단하기 위한 것이며,
+// createModelConfigAdapter 자체는 mocking하지 않는다 (테스트 대상이므로).
+// runner.ts의 import 경로가 변경되면 이 목록도 따라가야 한다.
+
+// model-config 모듈 모킹: getModuleModelConfig가 maxOutputTokens를 포함해 반환한다고 가정
+vi.mock('../model-config', () => ({
+  getModuleModelConfig: vi.fn(),
+  getModuleModelConfigForPreset: vi.fn(),
+  getAllModelSettingsForPreset: vi.fn(),
+}));
+
+// runner.ts가 import하는 외부/내부 의존성들이 side-effect 없이 로드되도록 모킹
+// @krdn/ai-analysis-kit: DB/프로바이더 초기화 없이 타입/함수만 노출
+vi.mock('@krdn/ai-analysis-kit', () => ({
+  runModule: vi.fn(),
+}));
+
+// DB를 직접 사용하는 내부 모듈들
+vi.mock('../../pipeline/control', () => ({
+  isPipelineCancelled: vi.fn().mockResolvedValue(false),
+  waitIfPaused: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../../pipeline/persist', () => ({
+  appendJobEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../persist-analysis', () => ({
+  persistAnalysisResult: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../module-cache', () => ({
+  hashAnalysisInput: vi.fn().mockReturnValue('hash'),
+  getCachedModuleResult: vi.fn().mockResolvedValue(null),
+  setCachedModuleResult: vi.fn().mockResolvedValue(undefined),
+}));
+
+// 모든 분석 모듈을 더미로 대체 (import side-effect 방지)
+vi.mock('../modules', () => ({
+  macroViewModule: { name: 'macro-view' },
+  segmentationModule: { name: 'segmentation' },
+  sentimentFramingModule: { name: 'sentiment-framing' },
+  messageImpactModule: { name: 'message-impact' },
+  riskMapModule: { name: 'risk-map' },
+  opportunityModule: { name: 'opportunity' },
+  strategyModule: { name: 'strategy' },
+  approvalRatingModule: { name: 'approval-rating' },
+  frameWarModule: { name: 'frame-war' },
+  crisisScenarioModule: { name: 'crisis-scenario' },
+  winSimulationModule: { name: 'win-simulation' },
+  fanLoyaltyIndexModule: { name: 'fan-loyalty-index' },
+  fandomNarrativeWarModule: { name: 'fandom-narrative-war' },
+  fandomCrisisScenarioModule: { name: 'fandom-crisis-scenario' },
+  releaseReceptionPredictionModule: { name: 'release-reception-prediction' },
+  crisisTypeClassifierModule: { name: 'crisis-type-classifier' },
+  reputationIndexModule: { name: 'reputation-index' },
+  stakeholderMapModule: { name: 'stakeholder-map' },
+  esgSentimentModule: { name: 'esg-sentiment' },
+  mediaFramingDominanceModule: { name: 'media-framing-dominance' },
+  csrCommunicationGapModule: { name: 'csr-communication-gap' },
+  reputationRecoverySimulationModule: { name: 'reputation-recovery-simulation' },
+  healthRiskPerceptionModule: { name: 'health-risk-perception' },
+  compliancePredictorModule: { name: 'compliance-predictor' },
+  performanceNarrativeModule: { name: 'performance-narrative' },
+  seasonOutlookPredictionModule: { name: 'season-outlook-prediction' },
+  marketSentimentIndexModule: { name: 'market-sentiment-index' },
+  informationAsymmetryModule: { name: 'information-asymmetry' },
+  catalystScenarioModule: { name: 'catalyst-scenario' },
+  investmentSignalModule: { name: 'investment-signal' },
+  institutionalReputationIndexModule: { name: 'institutional-reputation-index' },
+  educationOpinionFrameModule: { name: 'education-opinion-frame' },
+  educationCrisisScenarioModule: { name: 'education-crisis-scenario' },
+  educationOutcomeSimulationModule: { name: 'education-outcome-simulation' },
+}));
+
+vi.mock('../domain', () => ({
+  getDomainConfig: vi.fn().mockReturnValue({
+    stage4: { parallel: [], sequential: [] },
+  }),
+}));
+
+vi.mock('./pipeline-orchestrator', () => ({
+  runAnalysisPipeline: vi.fn(),
+}));
+
+describe('ModelConfigAdapter maxOutputTokens propagation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preset 어댑터는 DB에 저장된 maxOutputTokens를 ResolvedModelConfig로 전달한다', async () => {
+    vi.mocked(getModuleModelConfigForPreset).mockResolvedValueOnce({
+      provider: 'gemini',
+      model: 'gemini-2.5-flash',
+      maxOutputTokens: 24000,
+    });
+
+    const adapter = createModelConfigAdapter('political');
+    const resolved = await adapter.resolve('macro-view');
+
+    expect(resolved.maxOutputTokens).toBe(24000);
+    expect(resolved.provider).toBe('gemini');
+    expect(resolved.model).toBe('gemini-2.5-flash');
+  });
+
+  it('maxOutputTokens가 null이면 ResolvedModelConfig에 키를 넣지 않는다 (kit 기본값 사용)', async () => {
+    vi.mocked(getModuleModelConfigForPreset).mockResolvedValueOnce({
+      provider: 'gemini',
+      model: 'gemini-2.5-flash',
+      // maxOutputTokens 미설정
+    });
+
+    const adapter = createModelConfigAdapter();
+    const resolved = await adapter.resolve('macro-view');
+
+    expect('maxOutputTokens' in resolved).toBe(false);
+  });
+
+  it('maxOutputTokens=0이면 ResolvedModelConfig에 키가 존재하고 0으로 전달된다 (!= null 보장)', async () => {
+    vi.mocked(getModuleModelConfigForPreset).mockResolvedValueOnce({
+      provider: 'gemini',
+      model: 'gemini-2.5-flash',
+      maxOutputTokens: 0,
+    });
+
+    const adapter = createModelConfigAdapter('political');
+    const resolved = await adapter.resolve('macro-view');
+
+    expect('maxOutputTokens' in resolved).toBe(true);
+    expect(resolved.maxOutputTokens).toBe(0);
+  });
+});

--- a/packages/core/src/analysis/model-config.ts
+++ b/packages/core/src/analysis/model-config.ts
@@ -474,6 +474,7 @@ export async function getAllModelSettingsForPreset(presetSlug?: string): Promise
     moduleName: string;
     provider: AIProvider;
     model: string;
+    maxOutputTokens: number | null;
     isCustom: boolean;
     source: 'preset' | 'global' | 'default';
   }>
@@ -495,12 +496,16 @@ export async function getAllModelSettingsForPreset(presetSlug?: string): Promise
     .where(eq(presetModelSettings.presetSlug, presetSlug));
 
   const presetMap = new Map(
-    presetRows.map((r) => [r.moduleName, { provider: r.provider as AIProvider, model: r.model }]),
+    presetRows.map((r) => [
+      r.moduleName,
+      { provider: r.provider as AIProvider, model: r.model, maxOutputTokens: r.maxOutputTokens },
+    ]),
   );
 
   return globalSettings.map((s) => {
     const presetOverride = presetMap.get(s.moduleName);
     if (presetOverride) {
+      // presetOverride.maxOutputTokens === null이면 "이 프리셋은 글로벌 값을 명시적으로 클리어 → kit 기본값 사용"
       return { ...s, ...presetOverride, isCustom: true, source: 'preset' as const };
     }
     return { ...s, source: (s.isCustom ? 'global' : 'default') as 'global' | 'default' };

--- a/packages/core/src/analysis/model-config.ts
+++ b/packages/core/src/analysis/model-config.ts
@@ -285,6 +285,7 @@ export async function getModuleModelConfig(moduleName: string): Promise<ModuleMo
     .select({
       provider: modelSettings.provider,
       model: modelSettings.model,
+      maxOutputTokens: modelSettings.maxOutputTokens,
     })
     .from(modelSettings)
     .where(eq(modelSettings.moduleName, moduleName))
@@ -306,6 +307,7 @@ export async function getModuleModelConfig(moduleName: string): Promise<ModuleMo
       model: dbSetting.model,
       baseUrl: keyInfo?.baseUrl ?? undefined,
       apiKey: keyInfo?.apiKey ?? undefined,
+      maxOutputTokens: dbSetting.maxOutputTokens ?? undefined,
     };
   }
 
@@ -339,23 +341,36 @@ export async function getModuleModelConfig(moduleName: string): Promise<ModuleMo
  * DB 설정을 MODULE_MODEL_MAP에 머지하여 반환
  */
 export async function getAllModelSettings(): Promise<
-  Array<{ moduleName: string; provider: AIProvider; model: string; isCustom: boolean }>
+  Array<{
+    moduleName: string;
+    provider: AIProvider;
+    model: string;
+    maxOutputTokens: number | null;
+    isCustom: boolean;
+  }>
 > {
   const db = getDb();
   const dbSettings = await db.select().from(modelSettings);
 
   // DB 설정을 맵으로 변환
   const dbMap = new Map(
-    dbSettings.map((s) => [s.moduleName, { provider: s.provider as AIProvider, model: s.model }]),
+    dbSettings.map((s) => [
+      s.moduleName,
+      {
+        provider: s.provider as AIProvider,
+        model: s.model,
+        maxOutputTokens: s.maxOutputTokens ?? null,
+      },
+    ]),
   );
 
   // MODULE_MODEL_MAP의 모든 모듈에 대해 설정 반환
   return Object.entries(MODULE_MODEL_MAP).map(([moduleName, defaultConfig]) => {
     const custom = dbMap.get(moduleName);
     if (custom) {
-      return { moduleName, provider: custom.provider, model: custom.model, isCustom: true };
+      return { moduleName, ...custom, isCustom: true };
     }
-    return { moduleName, ...defaultConfig, isCustom: false };
+    return { moduleName, ...defaultConfig, maxOutputTokens: null, isCustom: false };
   });
 }
 
@@ -366,25 +381,44 @@ export async function upsertModelSetting(
   moduleName: string,
   provider: AIProvider,
   model: string,
-): Promise<{ moduleName: string; provider: AIProvider; model: string }> {
+  maxOutputTokens?: number | null,
+): Promise<{
+  moduleName: string;
+  provider: AIProvider;
+  model: string;
+  maxOutputTokens: number | null;
+}> {
   const db = getDb();
   const [result] = await db
     .insert(modelSettings)
-    .values({ moduleName, provider, model, updatedAt: new Date() })
+    .values({
+      moduleName,
+      provider,
+      model,
+      maxOutputTokens: maxOutputTokens ?? null,
+      updatedAt: new Date(),
+    })
     .onConflictDoUpdate({
       target: modelSettings.moduleName,
-      set: { provider, model, updatedAt: new Date() },
+      set: {
+        provider,
+        model,
+        maxOutputTokens: maxOutputTokens ?? null,
+        updatedAt: new Date(),
+      },
     })
     .returning({
       moduleName: modelSettings.moduleName,
       provider: modelSettings.provider,
       model: modelSettings.model,
+      maxOutputTokens: modelSettings.maxOutputTokens,
     });
 
   return {
     moduleName: result.moduleName,
     provider: result.provider as AIProvider,
     model: result.model,
+    maxOutputTokens: result.maxOutputTokens ?? null,
   };
 }
 
@@ -404,6 +438,7 @@ export async function getModuleModelConfigForPreset(
       .select({
         provider: presetModelSettings.provider,
         model: presetModelSettings.model,
+        maxOutputTokens: presetModelSettings.maxOutputTokens,
       })
       .from(presetModelSettings)
       .where(
@@ -421,6 +456,7 @@ export async function getModuleModelConfigForPreset(
         model: presetSetting.model,
         baseUrl: keyInfo?.baseUrl ?? undefined,
         apiKey: keyInfo?.apiKey ?? undefined,
+        maxOutputTokens: presetSetting.maxOutputTokens ?? undefined,
       };
     }
   }
@@ -479,23 +515,49 @@ export async function upsertPresetModelSetting(
   moduleName: string,
   provider: AIProvider,
   model: string,
-): Promise<{ presetSlug: string; moduleName: string; provider: AIProvider; model: string }> {
+  maxOutputTokens?: number | null,
+): Promise<{
+  presetSlug: string;
+  moduleName: string;
+  provider: AIProvider;
+  model: string;
+  maxOutputTokens: number | null;
+}> {
   const db = getDb();
   const [result] = await db
     .insert(presetModelSettings)
-    .values({ presetSlug, moduleName, provider, model, updatedAt: new Date() })
+    .values({
+      presetSlug,
+      moduleName,
+      provider,
+      model,
+      maxOutputTokens: maxOutputTokens ?? null,
+      updatedAt: new Date(),
+    })
     .onConflictDoUpdate({
       target: [presetModelSettings.presetSlug, presetModelSettings.moduleName],
-      set: { provider, model, updatedAt: new Date() },
+      set: {
+        provider,
+        model,
+        maxOutputTokens: maxOutputTokens ?? null,
+        updatedAt: new Date(),
+      },
     })
     .returning({
       presetSlug: presetModelSettings.presetSlug,
       moduleName: presetModelSettings.moduleName,
       provider: presetModelSettings.provider,
       model: presetModelSettings.model,
+      maxOutputTokens: presetModelSettings.maxOutputTokens,
     });
 
-  return { ...result, provider: result.provider as AIProvider };
+  return {
+    presetSlug: result.presetSlug,
+    moduleName: result.moduleName,
+    provider: result.provider as AIProvider,
+    model: result.model,
+    maxOutputTokens: result.maxOutputTokens ?? null,
+  };
 }
 
 /**

--- a/packages/core/src/analysis/runner.ts
+++ b/packages/core/src/analysis/runner.ts
@@ -143,6 +143,7 @@ const dbModelConfigAdapter: ModelConfigAdapter = {
       model: cfg.model,
       ...(cfg.baseUrl ? { baseUrl: cfg.baseUrl } : {}),
       ...(cfg.apiKey ? { apiKey: cfg.apiKey } : {}),
+      ...(cfg.maxOutputTokens != null ? { maxOutputTokens: cfg.maxOutputTokens } : {}),
     };
   },
 };
@@ -157,6 +158,7 @@ export function createModelConfigAdapter(presetSlug?: string): ModelConfigAdapte
         model: cfg.model,
         ...(cfg.baseUrl ? { baseUrl: cfg.baseUrl } : {}),
         ...(cfg.apiKey ? { apiKey: cfg.apiKey } : {}),
+        ...(cfg.maxOutputTokens != null ? { maxOutputTokens: cfg.maxOutputTokens } : {}),
       };
     },
   };

--- a/packages/core/src/db/schema/settings.ts
+++ b/packages/core/src/db/schema/settings.ts
@@ -17,6 +17,8 @@ export const modelSettings = pgTable(
     moduleName: text('module_name').notNull(),
     provider: text('provider').notNull(), // 'anthropic' | 'openai'
     model: text('model').notNull(),
+    /** 모듈별 LLM 출력 토큰 상한 (NULL이면 kit 기본 8192) */
+    maxOutputTokens: integer('max_output_tokens'),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
   (table) => [uniqueIndex('model_settings_module_name_idx').on(table.moduleName)],
@@ -31,6 +33,8 @@ export const presetModelSettings = pgTable(
     moduleName: text('module_name').notNull(), // 'macro-view', 'fan-loyalty-index', etc.
     provider: text('provider').notNull(),
     model: text('model').notNull(),
+    /** 프리셋 모듈별 LLM 출력 토큰 상한 (NULL이면 글로벌 → kit 기본) */
+    maxOutputTokens: integer('max_output_tokens'),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
   (table) => [

--- a/packages/core/src/types/analysis.ts
+++ b/packages/core/src/types/analysis.ts
@@ -6,6 +6,8 @@ export interface ModuleModelConfig {
   model: string;
   baseUrl?: string;
   apiKey?: string;
+  /** 모듈별 LLM 출력 토큰 상한 (없으면 kit 기본 8192) */
+  maxOutputTokens?: number;
 }
 
 // 프로바이더 키 정보 (per D-02, from provider-keys.ts)


### PR DESCRIPTION
## Summary

- 모듈별 \`maxOutputTokens\`를 DB에서 동적으로 조정 가능하도록 end-to-end 배선
- \`macro-view\` 기본값을 8192 → 24000으로 시드 (Job #274 시계열 트렌드 누락의 직접 원인 해결)
- 토큰 컷오프 시 단일 모듈 재실행을 위한 ad-hoc 스크립트 추가

Closes #133

## Test plan

- [x] core typecheck (\`pnpm --filter @ai-signalcraft/core build\`)
- [x] web typecheck (\`pnpm --filter @ai-signalcraft/web build\`)
- [x] vitest 전체 통과 (361 tests, 6 skipped)
- [x] 신규 단위 테스트 3건 — \`createModelConfigAdapter\`가 maxOutputTokens(=24000, =0, undefined)를 정확히 전파/생략 검증
- [x] DB 스키마 push 완료 (model_settings.max_output_tokens, preset_model_settings.max_output_tokens — 둘 다 nullable integer)
- [x] DB에 macro-view 24000 시드 적용 (운영 환경)
- [ ] **머지 후 운영 ais-prod-worker 재배포 필요** — 그 후 Job 274 macro-view를 단독 재실행해 \`outputTokens < 20000\`인지 확인하고 #133 close
  - 운영 worker 안에서: \`cd /app/packages/core && AIS_MODULE_CACHE=off pnpm exec tsx scripts/rerun-macro-view.ts 274\`
  - 검증: \`SELECT status, jsonb_extract_path(usage,'outputTokens') FROM analysis_results WHERE job_id=274 AND module='macro-view';\`
  - UI 확인: Job 274 대시보드 → \"시계열 트렌드\" 카드에 라인 차트 + 변곡점 라벨 표시

## 관련 후속 이슈 (본 PR 범위 외)

| # | 내용 |
|---|------|
| #134 | \`applyModelScenario\` / \`bulkUpdate\`가 max_output_tokens를 NULL wipe |
| #135 | \`getAllModelSettingsForPreset\` listing이 preset row의 max_output_tokens 누락 (이번 PR Task 6에서 일부 해소; 잔여 검증 필요) |
| #136 | \`settings.update\` / \`updatePreset\` 라우터의 wipe 회귀 (#134 묶음) |
| #137 | tRPC Zod 범위 \`min(512).max(65536)\` 통합 테스트 |

## 주의

- \`macro-view\` 출력 스키마 \`MacroViewSchema\` 필드 순서상 \`dailyMentionTrend\`가 마지막이라, 24000도 부족한 입력이 들어오면 또 컷오프될 수 있음. 검증 시 \`outputTokens\`가 20000 이상이면 별도 follow-up(스키마 reorder 또는 \`dailyMentionTrend\`를 LLM 출력에서 분리)을 파일링해야 함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)