### PR TITLE
fix(ci): collectors 테스트 환경 의존성 해소 (TZ + Playwright)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # day-window-collector.test.ts 등이 chromium 실행 — runner 캐시에 브라우저 + system lib 필요
+      - name: Install Playwright browsers
+        run: pnpm --filter @ai-signalcraft/collectors exec playwright install chromium --with-deps
+
       # 모든 워크스페이스 테스트 — web/core/collector/collectors 전체 회귀 차단
       - name: Run All Tests
         run: pnpm -r test

--- a/packages/collectors/package.json
+++ b/packages/collectors/package.json
@@ -7,7 +7,7 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "tsc",
-    "test": "vitest run"
+    "test": "TZ=Asia/Seoul vitest run"
   },
   "dependencies": {
     "cheerio": "^1.0.0",


### PR DESCRIPTION
## Summary

- `9ad7908`(ci: 모든 워크스페이스 테스트) 머지 후 collectors 테스트가 처음으로 CI에서 실행되며 두 가지 잠복 환경 의존성이 폭로됨
- 본 PR은 **collectors 워크스페이스 한정** — apps/collector의 TimescaleDB 통합 테스트 fail은 별도 follow-up

## Failures (CI 재현 → 본 PR 수정 범위)

| 테스트 | 원인 | 수정 |
|---|---|---|
| `dcinside.test.ts > parseDateText` 3건 (`expected 23 to be 24` 등) | KST 가정 코드를 UTC runner에서 `getDate()`/`getHours()`로 검증 | `TZ=Asia/Seoul` script prefix |
| `day-window-collector.test.ts` 8건 (`browserType.launch: Executable doesn't exist`) | runner에 chromium 미설치 | `playwright install chromium --with-deps` |

## Why script-level TZ (not vitest config)

- `test.env.TZ`는 vitest worker 부팅 *후* `process.env`에 머지됨 — Node ICU/TZ 캐시 시점 차이로 동작 불확실
- `TZ=Asia/Seoul vitest run`은 Node 부팅 *전* 환경에 박혀 확실
- cross-env는 Linux/macOS-only 환경에서 YAGNI

## Why workspace-filter for Playwright

- web/core/collector 워크스페이스는 chromium 불필요
- 전 워크스페이스 설치는 시간/디스크 낭비
- `--with-deps`는 ubuntu-latest system lib 누락 방지

## Verification

```bash
# 수정 전: CI 실패 재현 (KST 로컬에서 TZ만 UTC로 강제)
TZ=UTC pnpm test
# → dcinside 3건 FAIL ("expected 23 to be 24" 등)

# 수정 후: package.json TZ prefix가 환경 TZ를 덮어씀
TZ=UTC pnpm test
# → 116/116 PASS ✅
```

Playwright 부분은 CI에서 검증.

## ⚠️ Out of scope: apps/collector TimescaleDB 통합 테스트

본 PR이 collectors 부분을 통과시키자 그 다음으로 실행되는 `apps/collector` 테스트(33건)에서 `ECONNREFUSED 127.0.0.1:5432` 발견.

- main 베이스라인에서도 동일 실패 (broken DATABASE_URL 시뮬레이션으로 31 failed/102 passed 재현 확정)
- apps/collector 테스트는 진짜 PostgreSQL/TimescaleDB 통합 테스트 (`getDb().insert(...)`)
- CI 인프라 구축 = TimescaleDB service container + DATABASE_URL + drizzle push + apply-hypertables 마이그레이션
- 이건 별도 spec 가치가 있는 작업 (분리 권장)

main branch protection이 비활성 상태라 "Tests" check fail은 머지 차단 효과 없음 → PR #139/#140/#141 머지 자체는 reviewer 승인만 있으면 가능.

## Test plan

- [x] 로컬 KST 환경 `pnpm -r test` 통과 (main 베이스라인)
- [x] 로컬 `TZ=UTC pnpm test` (수정 전): dcinside 3건 FAIL 재현
- [x] 로컬 `TZ=UTC pnpm test` (수정 후): 116/116 PASS
- [x] CI에서 collectors 116/116 통과 (PR #142 run #25159444181)
- [ ] apps/collector 통합 테스트 인프라 — 별도 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
