### PR TITLE
fix(infra): collector-worker 메모리 제한 6g 설정

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -141,6 +141,8 @@ services:
     command: ["tsx", "apps/collector/src/queue/worker-process.ts"]
     restart: unless-stopped
     stop_grace_period: 60s
+    mem_limit: 6g
+    memswap_limit: 6g
     env_file:
       - ../.env.production
     environment:


### PR DESCRIPTION
## Summary

- `docker/docker-compose.prod.yml`의 `collector-worker` 서비스에 `mem_limit: 6g` + `memswap_limit: 6g` 추가
- 호스트 메모리를 인질로 잡던 메모리 폭주(17.48GiB / PIDS 16,070) 재발 방지
- 컨테이너 swap 사용 차단으로 호스트 swap 보호

Closes #144

## Why

2026-05-17 시스템 점검에서 ais-collector-worker가 다음 상태로 폭주:

| 항목 | 수치 |
|------|------|
| 컨테이너 메모리 | 17.48GiB (정상 ~2GiB) |
| PIDS | 16,070 (정상 수백) |
| CPU | 811% (8코어 점유) |
| 호스트 메모리 | 96.7% / 가용 812Mi |
| OOM Killer | 50+ 회 발동 |

근본 원인: compose에 mem_limit 미설정 + YouTube transcript API HTTP 429 재시도 큐 누적.

## What changed

```yaml
   collector-worker:
     ...
     restart: unless-stopped
     stop_grace_period: 60s
+    mem_limit: 6g
+    memswap_limit: 6g
     env_file:
       - ../.env.production
```

### 값 산정
- 정상: ~2GiB
- 폭주: ~17GiB
- 한도: **6GiB** (정상 ×3 여유 — 누수만 차단)
- `memswap_limit == mem_limit` → 컨테이너 swap 사용 불가

## Test plan

- [ ] 머지 후 GitHub Actions 자동 배포 트리거 확인
- [ ] `docker stats ais-collector-worker`에서 MEM LIMIT이 30.61GiB → 6GiB로 변경 확인
- [ ] 1~2일 모니터링 — 정상 워크로드가 6GiB 한도 내에서 처리되는지 확인
- [ ] OOMKilled 이벤트 발생 여부 모니터링 (정상 워크로드에서 발생 시 한도 상향 검토)
- [ ] `docker inspect ais-collector-worker | jq '.[0].HostConfig.Memory'` → `6442450944` 확인

## Follow-up (별도 이슈 권장)

1. YouTube transcript 429 재시도 로직 점검 (백오프 + 최대 재시도)
2. 다른 워커(`ais-prod-worker`, `ais-whisper-worker`) mem_limit 점검
3. 컨테이너 메모리 80% 도달 알림 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)