### PR TITLE
feat: @krdn/tickerlens 주식 분석 위젯 추가 (/stocks)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -15,6 +15,8 @@ const nextConfig: NextConfig = {
     'resend',
     'ai-sdk-provider-gemini-cli',
     '@google/gemini-cli-core',
+    '@krdn/tickerlens',
+    'yahoo-finance2',
   ],
   turbopack: {
     rules: {

--- a/apps/web/src/app/stocks/page.tsx
+++ b/apps/web/src/app/stocks/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { AppShell } from '@/components/layout/app-shell';
+import { AppSidebar } from '@/components/layout/app-sidebar';
+import { AppHeader } from '@/components/layout/app-header';
+import { StocksView } from '@/components/stocks/stocks-view';
+
+export default function StocksPage() {
+  return (
+    <AppShell
+      sidebar={(_open, onClose) => (
+        <AppSidebar
+          activeTab={-1}
+          onTabChange={() => onClose()}
+          activeJobId={null}
+          isRunning={false}
+          onJobSelect={() => {}}
+        />
+      )}
+      header={(onMenuClick) => (
+        <AppHeader activeTab={-1} activeJobId={null} onMenuClick={onMenuClick} />
+      )}
+    >
+      <div className="p-4">
+        <div className="mb-4">
+          <h1 className="text-xl font-bold text-slate-900">주식 분석</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            미국 주식 티커를 다중 관점으로 분석합니다 (powered by tickerlens)
+          </p>
+        </div>
+        <StocksView />
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Activity,
   Brain,
   BrainCircuit,
+  CandlestickChart,
   ChevronDown,
   Database,
   FileText,
@@ -273,6 +274,13 @@ export function AppSidebar({
               건강
             </Link>
           </div>
+          <Link
+            href="/stocks"
+            className="flex w-full items-center gap-2 rounded-md border px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-700/50"
+          >
+            <CandlestickChart className="h-3.5 w-3.5" />
+            주식 분석
+          </Link>
         </div>
       </div>
 

--- a/apps/web/src/components/stocks/__tests__/signal-badge.test.ts
+++ b/apps/web/src/components/stocks/__tests__/signal-badge.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { signalMeta } from '../signal-badge';
+
+describe('signalMeta', () => {
+  it('strong_buy/buy는 초록 계열, sell/strong_sell은 빨강 계열, hold는 중립', () => {
+    expect(signalMeta('strong_buy').tone).toBe('positive');
+    expect(signalMeta('buy').tone).toBe('positive');
+    expect(signalMeta('hold').tone).toBe('neutral');
+    expect(signalMeta('sell').tone).toBe('negative');
+    expect(signalMeta('strong_sell').tone).toBe('negative');
+  });
+
+  it('각 시그널에 한국어 라벨 제공', () => {
+    expect(signalMeta('strong_buy').label).toBe('적극 매수');
+    expect(signalMeta('hold').label).toBe('보유');
+  });
+});

--- a/apps/web/src/components/stocks/history-panel.tsx
+++ b/apps/web/src/components/stocks/history-panel.tsx
@@ -19,13 +19,19 @@ export function HistoryPanel({
   refreshKey: number;
 }) {
   const [rows, setRows] = useState<HistoryRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    setError(null);
     trpcClient.stocks.list
       .query({ limit: 20 })
       .then((r) => setRows(r as HistoryRow[]))
-      .catch(() => setRows([]));
+      .catch(() => setError('이력을 불러오지 못했습니다.'));
   }, [refreshKey]);
+
+  if (error) {
+    return <p className="text-xs text-red-600">{error}</p>;
+  }
 
   if (rows.length === 0) {
     return <p className="text-xs text-slate-400">분석 이력이 없습니다.</p>;

--- a/apps/web/src/components/stocks/history-panel.tsx
+++ b/apps/web/src/components/stocks/history-panel.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { trpcClient } from '@/lib/trpc';
+
+interface HistoryRow {
+  id: number;
+  ticker: string;
+  depth: string;
+  requestedBy: string;
+  createdAt: string | Date;
+}
+
+export function HistoryPanel({
+  onSelect,
+  refreshKey,
+}: {
+  onSelect: (id: number) => void;
+  refreshKey: number;
+}) {
+  const [rows, setRows] = useState<HistoryRow[]>([]);
+
+  useEffect(() => {
+    trpcClient.stocks.list
+      .query({ limit: 20 })
+      .then((r) => setRows(r as HistoryRow[]))
+      .catch(() => setRows([]));
+  }, [refreshKey]);
+
+  if (rows.length === 0) {
+    return <p className="text-xs text-slate-400">분석 이력이 없습니다.</p>;
+  }
+
+  return (
+    <ul className="space-y-1">
+      {rows.map((row) => (
+        <li key={row.id}>
+          <button
+            type="button"
+            onClick={() => onSelect(row.id)}
+            className="w-full rounded px-2 py-1.5 text-left text-xs hover:bg-slate-100"
+          >
+            <span className="font-medium text-slate-800">{row.ticker}</span>{' '}
+            <span className="text-slate-400">
+              · {row.requestedBy} · {new Date(row.createdAt).toLocaleString('ko-KR')}
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/components/stocks/perspective-cell.tsx
+++ b/apps/web/src/components/stocks/perspective-cell.tsx
@@ -12,7 +12,9 @@ interface PerspectiveResult {
   risks: string[];
   catalysts: string[];
 }
-type Slot = { ok: true; value: PerspectiveResult } | { ok: false; error: { message: string } };
+export type Slot =
+  | { ok: true; value: PerspectiveResult }
+  | { ok: false; error: { message: string } };
 
 export function PerspectiveCell({ slot, timeframe }: { slot: Slot; timeframe: string }) {
   const [open, setOpen] = useState(false);

--- a/apps/web/src/components/stocks/perspective-cell.tsx
+++ b/apps/web/src/components/stocks/perspective-cell.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+import { SignalBadge } from './signal-badge';
+
+// tickerlens 타입 (로컬 정의 — 클라이언트 번들에 tickerlens 끌어오지 않기 위함)
+interface PerspectiveResult {
+  signal: 'strong_buy' | 'buy' | 'hold' | 'sell' | 'strong_sell';
+  confidence: number;
+  thesis: string;
+  evidence: { label: string; value: string }[];
+  risks: string[];
+  catalysts: string[];
+}
+type Slot = { ok: true; value: PerspectiveResult } | { ok: false; error: { message: string } };
+
+export function PerspectiveCell({ slot, timeframe }: { slot: Slot; timeframe: string }) {
+  const [open, setOpen] = useState(false);
+
+  if (!slot.ok) {
+    return (
+      <div className="rounded border border-red-200 bg-red-50 p-3 text-xs text-red-700">
+        <div className="font-medium">{timeframe}</div>
+        <div className="mt-1">분석 실패: {slot.error.message}</div>
+      </div>
+    );
+  }
+
+  const p = slot.value;
+  return (
+    <button
+      type="button"
+      onClick={() => setOpen((v) => !v)}
+      className="w-full rounded border border-slate-200 p-3 text-left text-xs transition hover:border-slate-300"
+    >
+      <div className="flex items-center justify-between">
+        <span className="font-medium text-slate-500">{timeframe}</span>
+        <SignalBadge signal={p.signal} />
+      </div>
+      <div className="mt-1 text-slate-400">신뢰도 {Math.round(p.confidence * 100)}%</div>
+      <p className="mt-2 line-clamp-2 text-slate-700">{p.thesis}</p>
+      {open && (
+        <div className="mt-3 space-y-2 border-t border-slate-100 pt-2">
+          {p.evidence.length > 0 && (
+            <div>
+              <div className="font-medium text-slate-600">근거</div>
+              <ul className="mt-1 space-y-0.5">
+                {p.evidence.map((e, i) => (
+                  <li key={i} className="text-slate-600">
+                    {e.label}: {e.value}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {p.risks.length > 0 && (
+            <div>
+              <div className="font-medium text-slate-600">리스크</div>
+              <ul className="mt-1 list-disc pl-4 text-slate-600">
+                {p.risks.map((r, i) => (
+                  <li key={i}>{r}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {p.catalysts.length > 0 && (
+            <div>
+              <div className="font-medium text-slate-600">촉매</div>
+              <ul className="mt-1 list-disc pl-4 text-slate-600">
+                {p.catalysts.map((c, i) => (
+                  <li key={i}>{c}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/components/stocks/perspective-grid.tsx
+++ b/apps/web/src/components/stocks/perspective-grid.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { PerspectiveCell, type Slot } from './perspective-cell';
+
+type PersonaSlots = { long: Slot; mid: Slot; short: Slot };
+
+interface Perspectives {
+  value: PersonaSlots;
+  growth: PersonaSlots;
+  quant: PersonaSlots;
+  options: PersonaSlots;
+}
+
+const PERSONAS: { key: keyof Perspectives; label: string }[] = [
+  { key: 'value', label: 'Value (가치)' },
+  { key: 'growth', label: 'Growth (성장)' },
+  { key: 'quant', label: 'Quant (퀀트)' },
+  { key: 'options', label: 'Options (옵션)' },
+];
+const TIMEFRAMES: { key: keyof PersonaSlots; label: string }[] = [
+  { key: 'long', label: 'Long' },
+  { key: 'mid', label: 'Mid' },
+  { key: 'short', label: 'Short' },
+];
+
+export function PerspectiveGrid({ perspectives }: { perspectives: Perspectives }) {
+  return (
+    <div className="space-y-6">
+      {PERSONAS.map((persona) => (
+        <section key={persona.key}>
+          <h3 className="mb-2 text-sm font-semibold text-slate-800">{persona.label}</h3>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            {TIMEFRAMES.map((tf) => (
+              <PerspectiveCell
+                key={tf.key}
+                timeframe={tf.label}
+                slot={perspectives[persona.key][tf.key]}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/stocks/signal-badge.tsx
+++ b/apps/web/src/components/stocks/signal-badge.tsx
@@ -1,0 +1,29 @@
+type Signal = 'strong_buy' | 'buy' | 'hold' | 'sell' | 'strong_sell';
+type Tone = 'positive' | 'neutral' | 'negative';
+
+interface SignalMeta {
+  label: string;
+  tone: Tone;
+  className: string;
+}
+
+const MAP: Record<Signal, SignalMeta> = {
+  strong_buy: { label: '적극 매수', tone: 'positive', className: 'bg-green-100 text-green-800' },
+  buy: { label: '매수', tone: 'positive', className: 'bg-green-50 text-green-700' },
+  hold: { label: '보유', tone: 'neutral', className: 'bg-slate-100 text-slate-700' },
+  sell: { label: '매도', tone: 'negative', className: 'bg-red-50 text-red-700' },
+  strong_sell: { label: '적극 매도', tone: 'negative', className: 'bg-red-100 text-red-800' },
+};
+
+export function signalMeta(signal: Signal): SignalMeta {
+  return MAP[signal];
+}
+
+export function SignalBadge({ signal }: { signal: Signal }) {
+  const meta = signalMeta(signal);
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${meta.className}`}>
+      {meta.label}
+    </span>
+  );
+}

--- a/apps/web/src/components/stocks/snapshot-card.tsx
+++ b/apps/web/src/components/stocks/snapshot-card.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+interface Snapshot {
+  ticker: string;
+  asOf: string;
+  price: { last: number; change: number; changePct: number };
+  fundamentals: { marketCap: number; pe: number | null };
+  recommendations: { rating: string; targetMean: number };
+}
+
+export function SnapshotCard({ snapshot }: { snapshot: Snapshot }) {
+  const { price, fundamentals, recommendations } = snapshot;
+  const up = price.change >= 0;
+  return (
+    <div className="rounded-lg border border-slate-200 p-4">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-lg font-bold text-slate-900">{snapshot.ticker}</h2>
+        <span className="text-xs text-slate-400">
+          {new Date(snapshot.asOf).toLocaleString('ko-KR')}
+        </span>
+      </div>
+      <div className="mt-2 flex items-baseline gap-3">
+        <span className="text-2xl font-semibold">${price.last.toFixed(2)}</span>
+        <span className={up ? 'text-green-600' : 'text-red-600'}>
+          {up ? '+' : ''}
+          {price.change.toFixed(2)} ({price.changePct.toFixed(2)}%)
+        </span>
+      </div>
+      <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-600">
+        <div>
+          <dt className="text-slate-400">시가총액</dt>
+          <dd>${(fundamentals.marketCap / 1e9).toFixed(1)}B</dd>
+        </div>
+        <div>
+          <dt className="text-slate-400">PER</dt>
+          <dd>{fundamentals.pe?.toFixed(1) ?? '—'}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-400">애널리스트</dt>
+          <dd>{recommendations.rating}</dd>
+        </div>
+        <div>
+          <dt className="text-slate-400">목표가(평균)</dt>
+          <dd>${recommendations.targetMean.toFixed(2)}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/apps/web/src/components/stocks/stocks-view.tsx
+++ b/apps/web/src/components/stocks/stocks-view.tsx
@@ -1,18 +1,17 @@
 'use client';
 
 import { useState, useCallback } from 'react';
+import type { inferRouterOutputs } from '@trpc/server';
 import { TickerInput } from './ticker-input';
 import { SnapshotCard } from './snapshot-card';
 import { PerspectiveGrid } from './perspective-grid';
 import { HistoryPanel } from './history-panel';
 import { trpcClient } from '@/lib/trpc';
+import type { AppRouter } from '@/server/trpc/router';
 
-type AnalysisResult = {
-  ticker: string;
-  asOf: string;
-  snapshot: Parameters<typeof SnapshotCard>[0]['snapshot'];
-  perspectives: Parameters<typeof PerspectiveGrid>[0]['perspectives'];
-};
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+// analyze는 { id, ...AnalysisResult }를 반환 — id를 제외해 getById(jsonb result)와 동일 형태로 통일
+type AnalysisResult = Omit<RouterOutputs['stocks']['analyze'], 'id'>;
 
 export function StocksView() {
   const [result, setResult] = useState<AnalysisResult | null>(null);
@@ -26,7 +25,7 @@ export function StocksView() {
     trpcClient.stocks.analyze
       .mutate({ ticker, depth })
       .then((res) => {
-        setResult(res as unknown as AnalysisResult);
+        setResult(res);
         setRefreshKey((k) => k + 1);
       })
       .catch((e: unknown) => setError(e instanceof Error ? e.message : '분석 실패'))
@@ -38,7 +37,8 @@ export function StocksView() {
     setError(null);
     trpcClient.stocks.getById
       .query({ id })
-      .then((row) => setResult((row as { result: AnalysisResult }).result))
+      // result는 jsonb(unknown) — tickerlens AnalysisResult가 저장된 단일 경계 캐스트
+      .then((row) => setResult(row.result as AnalysisResult))
       .catch((e: unknown) => setError(e instanceof Error ? e.message : '조회 실패'))
       .finally(() => setIsLoading(false));
   }, []);

--- a/apps/web/src/components/stocks/stocks-view.tsx
+++ b/apps/web/src/components/stocks/stocks-view.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { TickerInput } from './ticker-input';
+import { SnapshotCard } from './snapshot-card';
+import { PerspectiveGrid } from './perspective-grid';
+import { HistoryPanel } from './history-panel';
+import { trpcClient } from '@/lib/trpc';
+
+type AnalysisResult = {
+  ticker: string;
+  asOf: string;
+  snapshot: Parameters<typeof SnapshotCard>[0]['snapshot'];
+  perspectives: Parameters<typeof PerspectiveGrid>[0]['perspectives'];
+};
+
+export function StocksView() {
+  const [result, setResult] = useState<AnalysisResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const handleAnalyze = useCallback((ticker: string, depth: 'full' | 'lite') => {
+    setIsLoading(true);
+    setError(null);
+    trpcClient.stocks.analyze
+      .mutate({ ticker, depth })
+      .then((res) => {
+        setResult(res as unknown as AnalysisResult);
+        setRefreshKey((k) => k + 1);
+      })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : '분석 실패'))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const handleSelectHistory = useCallback((id: number) => {
+    setIsLoading(true);
+    setError(null);
+    trpcClient.stocks.getById
+      .query({ id })
+      .then((row) => setResult((row as { result: AnalysisResult }).result))
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : '조회 실패'))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_280px]">
+      <div className="space-y-4">
+        <TickerInput onAnalyze={handleAnalyze} isLoading={isLoading} />
+        {error && (
+          <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+        {isLoading && (
+          <p className="text-sm text-slate-500">분석 중입니다… (정밀 분석은 수십 초 소요)</p>
+        )}
+        {result && !isLoading && (
+          <div className="space-y-4">
+            <SnapshotCard snapshot={result.snapshot} />
+            <PerspectiveGrid perspectives={result.perspectives} />
+          </div>
+        )}
+      </div>
+      <aside>
+        <h3 className="mb-2 text-sm font-semibold text-slate-700">최근 분석 (팀 공유)</h3>
+        <HistoryPanel onSelect={handleSelectHistory} refreshKey={refreshKey} />
+      </aside>
+    </div>
+  );
+}

--- a/apps/web/src/components/stocks/ticker-input.tsx
+++ b/apps/web/src/components/stocks/ticker-input.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface TickerInputProps {
+  onAnalyze: (ticker: string, depth: 'full' | 'lite') => void;
+  isLoading: boolean;
+}
+
+export function TickerInput({ onAnalyze, isLoading }: TickerInputProps) {
+  const [ticker, setTicker] = useState('');
+  const [depth, setDepth] = useState<'full' | 'lite'>('lite');
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        <input
+          value={ticker}
+          onChange={(e) => setTicker(e.target.value.toUpperCase())}
+          placeholder="티커 (예: AAPL)"
+          className="flex-1 rounded border border-slate-300 px-3 py-2 text-sm"
+          maxLength={10}
+        />
+        <Button
+          onClick={() => onAnalyze(ticker.trim(), depth)}
+          disabled={isLoading || !ticker.trim()}
+        >
+          {isLoading ? '분석 중…' : '분석'}
+        </Button>
+      </div>
+      <div className="flex items-center gap-3 text-xs">
+        <label className="flex items-center gap-1">
+          <input type="radio" checked={depth === 'lite'} onChange={() => setDepth('lite')} />
+          빠른 분석 (4회 호출)
+        </label>
+        <label className="flex items-center gap-1">
+          <input type="radio" checked={depth === 'full'} onChange={() => setDepth('full')} />
+          정밀 분석 (12회 LLM 호출, 비용 발생)
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/server/trpc/router.ts
+++ b/apps/web/src/server/trpc/router.ts
@@ -22,6 +22,7 @@ import { seriesRouter } from './routers/series';
 import { subscriptionsRouter } from './routers/subscriptions';
 import { manipulationRouter } from './routers/manipulation';
 import { manipulationAlertsRouter } from './routers/manipulation-alerts';
+import { stocksRouter } from './routers/stocks';
 
 export const appRouter = router({
   analysis: analysisRouter,
@@ -47,5 +48,6 @@ export const appRouter = router({
   ontology: ontologyRouter,
   llmInsights: llmInsightsRouter,
   series: seriesRouter,
+  stocks: stocksRouter,
 });
 export type AppRouter = typeof appRouter;

--- a/apps/web/src/server/trpc/routers/__tests__/stocks.test.ts
+++ b/apps/web/src/server/trpc/routers/__tests__/stocks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { makeProtectedCtx } from '../../__tests__/test-helpers';
+import { makeProtectedCtx, mockDbSelect } from '../../__tests__/test-helpers';
 import { stocksRouter } from '../stocks';
 
 // vi.mock은 파일 최상단에서 호이스팅되어야 하므로 setupTrpcTestEnv() 대신 직접 정의
@@ -18,11 +18,36 @@ vi.mock('@ai-signalcraft/core', async () => {
   };
 });
 
-function ctxWithInsert() {
+function makeInsertSpy() {
+  return vi.fn(() => ({ values: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }));
+}
+
+// insert 호출 여부를 검증할 수 있도록 spy로 감싼 ctx 빌더.
+function ctxWithInsertSpy(insertSpy: ReturnType<typeof makeInsertSpy>) {
   const ctx = makeProtectedCtx() as Record<string, unknown>;
   (ctx as { db: unknown }).db = {
     ...(ctx.db as object),
-    insert: () => ({ values: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }),
+    insert: insertSpy,
+  };
+  return ctx as never;
+}
+
+// select 체인이 주어진 rows를 반환하도록 모킹한 ctx 빌더 (list/getById용).
+// 미들웨어의 첫 select(teamMembers 조회)는 기본 동작을 유지하고,
+// 라우터 본문의 두 번째 select부터 mockDbSelect(rows)로 응답한다.
+function ctxWithSelect<T>(rows: T[]) {
+  const ctx = makeProtectedCtx() as Record<string, unknown>;
+  const membershipSelect = (ctx.db as { select: (...a: unknown[]) => unknown }).select;
+  const bodySelect = mockDbSelect(rows);
+  let firstCall = true;
+  (ctx as { db: unknown }).db = {
+    select: (...args: unknown[]) => {
+      if (firstCall) {
+        firstCall = false;
+        return membershipSelect(...args);
+      }
+      return bodySelect();
+    },
   };
   return ctx as never;
 }
@@ -33,20 +58,24 @@ describe('stocksRouter.analyze', () => {
   });
 
   it('잘못된 티커 형식은 입력 검증에서 거부', async () => {
-    const caller = stocksRouter.createCaller(ctxWithInsert());
+    const caller = stocksRouter.createCaller(ctxWithInsertSpy(makeInsertSpy()));
     await expect(caller.analyze({ ticker: '123!@#', depth: 'lite' })).rejects.toThrow();
     expect(analyzeTickerMock).not.toHaveBeenCalled();
   });
 
-  it('meta.completed===0이면 TRPCError로 전체 실패 처리', async () => {
+  it('meta.completed===0이면 INTERNAL_SERVER_ERROR + DB insert 미호출', async () => {
     analyzeTickerMock.mockResolvedValue({
       ticker: 'AAPL',
       asOf: '2026-05-29T00:00:00Z',
       perspectives: {},
       meta: { completed: 0, failed: 12, durationMs: 100, depth: 'lite' },
     });
-    const caller = stocksRouter.createCaller(ctxWithInsert());
-    await expect(caller.analyze({ ticker: 'AAPL', depth: 'lite' })).rejects.toThrow();
+    const insertSpy = makeInsertSpy();
+    const caller = stocksRouter.createCaller(ctxWithInsertSpy(insertSpy));
+    await expect(caller.analyze({ ticker: 'AAPL', depth: 'lite' })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+    expect(insertSpy).not.toHaveBeenCalled();
   });
 
   it('부분 성공(completed>0)이면 DB 저장 후 결과 반환', async () => {
@@ -56,9 +85,34 @@ describe('stocksRouter.analyze', () => {
       perspectives: {},
       meta: { completed: 8, failed: 4, durationMs: 100, depth: 'lite', totalCostUsd: 0.12 },
     });
-    const caller = stocksRouter.createCaller(ctxWithInsert());
+    const caller = stocksRouter.createCaller(ctxWithInsertSpy(makeInsertSpy()));
     const res = await caller.analyze({ ticker: 'AAPL', depth: 'lite' });
     expect(res.ticker).toBe('AAPL');
     expect(analyzeTickerMock).toHaveBeenCalledWith('AAPL', { depth: 'lite' });
+  });
+});
+
+describe('stocksRouter.getById', () => {
+  it('조회 결과 없으면 NOT_FOUND', async () => {
+    const caller = stocksRouter.createCaller(ctxWithSelect([]));
+    await expect(caller.getById({ id: 999 })).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
+
+describe('stocksRouter.list', () => {
+  it('limit 지정 시 행 배열 반환', async () => {
+    const rows = [
+      {
+        id: 2,
+        ticker: 'TSLA',
+        depth: 'lite',
+        requestedBy: 'u1',
+        asOf: new Date(),
+        createdAt: new Date(),
+      },
+    ];
+    const caller = stocksRouter.createCaller(ctxWithSelect(rows));
+    const res = await caller.list({ limit: 5 });
+    expect(res).toEqual(rows);
   });
 });

--- a/apps/web/src/server/trpc/routers/__tests__/stocks.test.ts
+++ b/apps/web/src/server/trpc/routers/__tests__/stocks.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeProtectedCtx } from '../../__tests__/test-helpers';
+import { stocksRouter } from '../stocks';
+
+// vi.mock은 파일 최상단에서 호이스팅되어야 하므로 setupTrpcTestEnv() 대신 직접 정의
+vi.mock('../../../auth', () => ({ auth: vi.fn().mockResolvedValue(null) }));
+vi.mock('next-auth', () => ({ default: vi.fn() }));
+vi.mock('next/headers', () => ({ cookies: vi.fn().mockReturnValue({ get: vi.fn() }) }));
+
+const analyzeTickerMock = vi.fn();
+vi.mock('@ai-signalcraft/core', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@ai-signalcraft/core');
+  return {
+    ...actual,
+    analyzeTicker: (...a: unknown[]) => analyzeTickerMock(...a),
+    getDb: () => ({}),
+    redisConnection: {},
+  };
+});
+
+function ctxWithInsert() {
+  const ctx = makeProtectedCtx() as Record<string, unknown>;
+  (ctx as { db: unknown }).db = {
+    ...(ctx.db as object),
+    insert: () => ({ values: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }),
+  };
+  return ctx as never;
+}
+
+describe('stocksRouter.analyze', () => {
+  beforeEach(() => {
+    analyzeTickerMock.mockReset();
+  });
+
+  it('잘못된 티커 형식은 입력 검증에서 거부', async () => {
+    const caller = stocksRouter.createCaller(ctxWithInsert());
+    await expect(caller.analyze({ ticker: '123!@#', depth: 'lite' })).rejects.toThrow();
+    expect(analyzeTickerMock).not.toHaveBeenCalled();
+  });
+
+  it('meta.completed===0이면 TRPCError로 전체 실패 처리', async () => {
+    analyzeTickerMock.mockResolvedValue({
+      ticker: 'AAPL',
+      asOf: '2026-05-29T00:00:00Z',
+      perspectives: {},
+      meta: { completed: 0, failed: 12, durationMs: 100, depth: 'lite' },
+    });
+    const caller = stocksRouter.createCaller(ctxWithInsert());
+    await expect(caller.analyze({ ticker: 'AAPL', depth: 'lite' })).rejects.toThrow();
+  });
+
+  it('부분 성공(completed>0)이면 DB 저장 후 결과 반환', async () => {
+    analyzeTickerMock.mockResolvedValue({
+      ticker: 'AAPL',
+      asOf: '2026-05-29T00:00:00Z',
+      perspectives: {},
+      meta: { completed: 8, failed: 4, durationMs: 100, depth: 'lite', totalCostUsd: 0.12 },
+    });
+    const caller = stocksRouter.createCaller(ctxWithInsert());
+    const res = await caller.analyze({ ticker: 'AAPL', depth: 'lite' });
+    expect(res.ticker).toBe('AAPL');
+    expect(analyzeTickerMock).toHaveBeenCalledWith('AAPL', { depth: 'lite' });
+  });
+});

--- a/apps/web/src/server/trpc/routers/stocks.ts
+++ b/apps/web/src/server/trpc/routers/stocks.ts
@@ -24,7 +24,7 @@ export const stocksRouter = router({
       if (result.meta.completed === 0) {
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
-          message: `${ticker} 분석에 실패했습니다 (모든 관점 실패). 프로바이더 키 설정을 확인하세요.`,
+          message: `${ticker} 분석에 실패했습니다 (모든 관점 실패). 잠시 후 다시 시도하세요.`,
         });
       }
 

--- a/apps/web/src/server/trpc/routers/stocks.ts
+++ b/apps/web/src/server/trpc/routers/stocks.ts
@@ -1,0 +1,76 @@
+import { TRPCError } from '@trpc/server';
+import { desc, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { analyzeTicker, stockAnalyses } from '@ai-signalcraft/core';
+import { protectedProcedure, router } from '../init';
+
+export const stocksRouter = router({
+  analyze: protectedProcedure
+    .input(
+      z.object({
+        ticker: z
+          .string()
+          .trim()
+          .min(1)
+          .max(10)
+          .regex(/^[A-Za-z.-]+$/, '티커는 영문/마침표/하이픈만 허용됩니다'),
+        depth: z.enum(['full', 'lite']).default('lite'),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const ticker = input.ticker.toUpperCase();
+      const result = await analyzeTicker(ticker, { depth: input.depth });
+
+      if (result.meta.completed === 0) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `${ticker} 분석에 실패했습니다 (모든 관점 실패). 프로바이더 키 설정을 확인하세요.`,
+        });
+      }
+
+      const [row] = await ctx.db
+        .insert(stockAnalyses)
+        .values({
+          requestedBy: ctx.userId,
+          ticker,
+          depth: input.depth,
+          asOf: new Date(result.asOf),
+          result,
+          costUsd: result.meta.totalCostUsd != null ? String(result.meta.totalCostUsd) : null,
+        })
+        .returning({ id: stockAnalyses.id });
+
+      return { id: row.id, ...result };
+    }),
+
+  list: protectedProcedure
+    .input(z.object({ limit: z.number().int().min(1).max(100).default(20) }).optional())
+    .query(async ({ ctx, input }) => {
+      return ctx.db
+        .select({
+          id: stockAnalyses.id,
+          ticker: stockAnalyses.ticker,
+          depth: stockAnalyses.depth,
+          requestedBy: stockAnalyses.requestedBy,
+          asOf: stockAnalyses.asOf,
+          createdAt: stockAnalyses.createdAt,
+        })
+        .from(stockAnalyses)
+        .orderBy(desc(stockAnalyses.createdAt))
+        .limit(input?.limit ?? 20);
+    }),
+
+  getById: protectedProcedure
+    .input(z.object({ id: z.number().int() }))
+    .query(async ({ ctx, input }) => {
+      const [row] = await ctx.db
+        .select()
+        .from(stockAnalyses)
+        .where(eq(stockAnalyses.id, input.id))
+        .limit(1);
+      if (!row) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: '분석 이력을 찾을 수 없습니다' });
+      }
+      return row;
+    }),
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "@ai-signalcraft/collector": "workspace:*",
     "@ai-signalcraft/collectors": "workspace:*",
     "@krdn/llm-gateway": "github:krdn/llm-gateway#v3.2.0",
+    "@krdn/tickerlens": "^0.1.0",
     "@trpc/client": "^11.0.0",
     "@xenova/transformers": "^2.17.0",
     "bullmq": "^5.0.0",

--- a/packages/core/src/analysis/index.ts
+++ b/packages/core/src/analysis/index.ts
@@ -15,3 +15,4 @@ export * from './collection-limits';
 export * from './preprocessing';
 export * from './cost-calculator';
 export * from './graph-builder';
+export { analyzeTicker } from './stocks/analyze-ticker';

--- a/packages/core/src/analysis/model-config.ts
+++ b/packages/core/src/analysis/model-config.ts
@@ -237,7 +237,7 @@ export async function applyModelScenario(
 /**
  * 프로바이더 타입에 해당하는 활성 프로바이더 키에서 연결 정보를 가져옴
  */
-async function getProviderKeyInfo(
+export async function getProviderKeyInfo(
   providerType: string,
   targetModel?: string,
 ): Promise<{ selectedModel: string | null; baseUrl: string | null; apiKey: string | null } | null> {

--- a/packages/core/src/analysis/stocks/__tests__/analyze-ticker.test.ts
+++ b/packages/core/src/analysis/stocks/__tests__/analyze-ticker.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { analyzeTicker } from '../analyze-ticker';
+
+// tickerlens와 키 조회를 모킹 — 실제 LLM/Yahoo 호출 차단
+const composeMock = vi.fn();
+vi.mock('@krdn/tickerlens', () => ({
+  composeTickerAnalysis: (...args: unknown[]) => composeMock(...args),
+}));
+
+const getProviderKeyInfoMock = vi.fn();
+vi.mock('../../model-config', () => ({
+  getProviderKeyInfo: (...args: unknown[]) => getProviderKeyInfoMock(...args),
+}));
+
+describe('analyzeTicker', () => {
+  beforeEach(() => {
+    composeMock.mockReset();
+    getProviderKeyInfoMock.mockReset();
+  });
+
+  it('depth 미지정 시 lite를 기본값으로 composeTickerAnalysis에 전달', async () => {
+    composeMock.mockResolvedValue({ ticker: 'AAPL' });
+    await analyzeTicker('AAPL');
+    expect(composeMock).toHaveBeenCalledWith('AAPL', expect.objectContaining({ depth: 'lite' }));
+  });
+
+  it('어댑터 resolve가 복호화된 apiKey와 고정 provider/model을 반환', async () => {
+    getProviderKeyInfoMock.mockResolvedValue({
+      selectedModel: null,
+      baseUrl: null,
+      apiKey: 'sk-decrypted',
+    });
+    composeMock.mockImplementation(async (_ticker, opts) => {
+      const resolved = await opts.configAdapter.resolve('tickerlens.value.long');
+      expect(resolved).toEqual({
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        apiKey: 'sk-decrypted',
+      });
+      return { ticker: 'AAPL' };
+    });
+    await analyzeTicker('AAPL', { depth: 'full' });
+    expect(composeMock).toHaveBeenCalledWith('AAPL', expect.objectContaining({ depth: 'full' }));
+  });
+
+  it('apiKey 미설정 시 어댑터 resolve가 한국어 에러 throw', async () => {
+    getProviderKeyInfoMock.mockResolvedValue({ selectedModel: null, baseUrl: null, apiKey: null });
+    composeMock.mockImplementation(async (_ticker, opts) => {
+      await opts.configAdapter.resolve('tickerlens.value.long');
+      return { ticker: 'AAPL' };
+    });
+    await expect(analyzeTicker('AAPL')).rejects.toThrow(/프로바이더 키가 설정되지 않/);
+  });
+});

--- a/packages/core/src/analysis/stocks/__tests__/analyze-ticker.test.ts
+++ b/packages/core/src/analysis/stocks/__tests__/analyze-ticker.test.ts
@@ -19,6 +19,11 @@ describe('analyzeTicker', () => {
   });
 
   it('depth 미지정 시 lite를 기본값으로 composeTickerAnalysis에 전달', async () => {
+    getProviderKeyInfoMock.mockResolvedValue({
+      selectedModel: null,
+      baseUrl: null,
+      apiKey: 'sk-decrypted',
+    });
     composeMock.mockResolvedValue({ ticker: 'AAPL' });
     await analyzeTicker('AAPL');
     expect(composeMock).toHaveBeenCalledWith('AAPL', expect.objectContaining({ depth: 'lite' }));
@@ -43,12 +48,27 @@ describe('analyzeTicker', () => {
     expect(composeMock).toHaveBeenCalledWith('AAPL', expect.objectContaining({ depth: 'full' }));
   });
 
-  it('apiKey 미설정 시 어댑터 resolve가 한국어 에러 throw', async () => {
-    getProviderKeyInfoMock.mockResolvedValue({ selectedModel: null, baseUrl: null, apiKey: null });
+  it('baseUrl이 설정된 경우 resolve 결과에 baseUrl이 포함', async () => {
+    getProviderKeyInfoMock.mockResolvedValue({
+      selectedModel: null,
+      baseUrl: 'https://example.com',
+      apiKey: 'sk-x',
+    });
     composeMock.mockImplementation(async (_ticker, opts) => {
-      await opts.configAdapter.resolve('tickerlens.value.long');
+      const resolved = await opts.configAdapter.resolve('tickerlens.value.long');
+      expect(resolved).toEqual({
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        apiKey: 'sk-x',
+        baseUrl: 'https://example.com',
+      });
       return { ticker: 'AAPL' };
     });
+    await analyzeTicker('AAPL');
+  });
+
+  it('apiKey 미설정 시 한국어 에러 throw', async () => {
+    getProviderKeyInfoMock.mockResolvedValue({ selectedModel: null, baseUrl: null, apiKey: null });
     await expect(analyzeTicker('AAPL')).rejects.toThrow(/프로바이더 키가 설정되지 않/);
   });
 });

--- a/packages/core/src/analysis/stocks/analyze-ticker.ts
+++ b/packages/core/src/analysis/stocks/analyze-ticker.ts
@@ -1,38 +1,35 @@
 import { composeTickerAnalysis, type AnalysisResult } from '@krdn/tickerlens';
-import type { ModelConfigAdapter } from '@krdn/llm-gateway/adapters';
-import type { AIProvider } from '@krdn/llm-gateway';
+import type { ModelConfigAdapter, AIProvider } from '@krdn/llm-gateway';
 import { getProviderKeyInfo } from '../model-config';
 
 // 주식 분석용 고정 모델 (per-persona 튜닝은 YAGNI — 단일 모델로 16개 모듈 모두 처리)
 const STOCK_PROVIDER: AIProvider = 'anthropic';
 const STOCK_MODEL = 'claude-sonnet-4-6';
 
-/** 모듈 이름과 무관하게 단일 provider/model + 복호화 키를 resolve하는 어댑터 */
-function createStockConfigAdapter(): ModelConfigAdapter {
-  return {
-    async resolve(_moduleName: string) {
-      const keyInfo = await getProviderKeyInfo(STOCK_PROVIDER, STOCK_MODEL);
-      if (!keyInfo?.apiKey) {
-        throw new Error(
-          `주식 분석용 프로바이더 키가 설정되지 않았습니다 (${STOCK_PROVIDER}). 설정에서 키를 등록하세요.`,
-        );
-      }
-      return {
-        provider: STOCK_PROVIDER,
-        model: STOCK_MODEL,
-        apiKey: keyInfo.apiKey,
-        ...(keyInfo.baseUrl ? { baseUrl: keyInfo.baseUrl } : {}),
-      };
-    },
-  };
-}
-
 export async function analyzeTicker(
   ticker: string,
   opts?: { depth?: 'full' | 'lite' },
 ): Promise<AnalysisResult> {
-  return composeTickerAnalysis(ticker, {
-    configAdapter: createStockConfigAdapter(),
-    depth: opts?.depth ?? 'lite',
-  });
+  // 키를 진입부에서 한 번 검증 — Yahoo 페치 전 즉시 실패, DB 조회 1회로 축소
+  const keyInfo = await getProviderKeyInfo(STOCK_PROVIDER, STOCK_MODEL);
+  if (!keyInfo?.apiKey) {
+    throw new Error(
+      `주식 분석용 프로바이더 키가 설정되지 않았습니다 (${STOCK_PROVIDER}). 설정에서 키를 등록하세요.`,
+    );
+  }
+  const apiKey = keyInfo.apiKey;
+
+  // 모듈 이름과 무관하게 단일 provider/model + 복호화 키를 resolve (클로저 바인딩)
+  const configAdapter: ModelConfigAdapter = {
+    async resolve(_moduleName: string) {
+      return {
+        provider: STOCK_PROVIDER,
+        model: STOCK_MODEL,
+        apiKey,
+        ...(keyInfo.baseUrl ? { baseUrl: keyInfo.baseUrl } : {}),
+      };
+    },
+  };
+
+  return composeTickerAnalysis(ticker, { configAdapter, depth: opts?.depth ?? 'lite' });
 }

--- a/packages/core/src/analysis/stocks/analyze-ticker.ts
+++ b/packages/core/src/analysis/stocks/analyze-ticker.ts
@@ -1,0 +1,38 @@
+import { composeTickerAnalysis, type AnalysisResult } from '@krdn/tickerlens';
+import type { ModelConfigAdapter } from '@krdn/llm-gateway/adapters';
+import type { AIProvider } from '@krdn/llm-gateway';
+import { getProviderKeyInfo } from '../model-config';
+
+// 주식 분석용 고정 모델 (per-persona 튜닝은 YAGNI — 단일 모델로 16개 모듈 모두 처리)
+const STOCK_PROVIDER: AIProvider = 'anthropic';
+const STOCK_MODEL = 'claude-sonnet-4-6';
+
+/** 모듈 이름과 무관하게 단일 provider/model + 복호화 키를 resolve하는 어댑터 */
+function createStockConfigAdapter(): ModelConfigAdapter {
+  return {
+    async resolve(_moduleName: string) {
+      const keyInfo = await getProviderKeyInfo(STOCK_PROVIDER, STOCK_MODEL);
+      if (!keyInfo?.apiKey) {
+        throw new Error(
+          `주식 분석용 프로바이더 키가 설정되지 않았습니다 (${STOCK_PROVIDER}). 설정에서 키를 등록하세요.`,
+        );
+      }
+      return {
+        provider: STOCK_PROVIDER,
+        model: STOCK_MODEL,
+        apiKey: keyInfo.apiKey,
+        ...(keyInfo.baseUrl ? { baseUrl: keyInfo.baseUrl } : {}),
+      };
+    },
+  };
+}
+
+export async function analyzeTicker(
+  ticker: string,
+  opts?: { depth?: 'full' | 'lite' },
+): Promise<AnalysisResult> {
+  return composeTickerAnalysis(ticker, {
+    configAdapter: createStockConfigAdapter(),
+    depth: opts?.depth ?? 'lite',
+  });
+}

--- a/packages/core/src/db/schema/index.ts
+++ b/packages/core/src/db/schema/index.ts
@@ -12,3 +12,4 @@ export * from './ontology';
 export * from './series';
 export * from './alerts';
 export * from './manipulation';
+export * from './stocks';

--- a/packages/core/src/db/schema/stocks.ts
+++ b/packages/core/src/db/schema/stocks.ts
@@ -1,0 +1,13 @@
+import { pgTable, integer, text, timestamp, jsonb, numeric } from 'drizzle-orm/pg-core';
+
+// D-XX: 주식 분석 이력 (tickerlens 위젯)
+export const stockAnalyses = pgTable('stock_analyses', {
+  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+  requestedBy: text('requested_by').notNull(), // 실행자 (표시용, 격리 아님)
+  ticker: text('ticker').notNull(),
+  depth: text('depth').notNull(), // 'full' | 'lite'
+  asOf: timestamp('as_of').notNull(),
+  result: jsonb('result').notNull(), // tickerlens AnalysisResult 전체
+  costUsd: numeric('cost_usd'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,9 @@ importers:
       '@krdn/llm-gateway':
         specifier: github:krdn/llm-gateway#v3.2.0
         version: https://codeload.github.com/krdn/llm-gateway/tar.gz/41911cd015aca1d7b9735f33902632ec078ada64(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.1))(zod@3.25.76)
+      '@krdn/tickerlens':
+        specifier: ^0.1.0
+        version: 0.1.0(@krdn/llm-gateway@https://codeload.github.com/krdn/llm-gateway/tar.gz/41911cd015aca1d7b9735f33902632ec078ada64(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.1))(zod@3.25.76))(zod@3.25.76)
       '@trpc/client':
         specifier: ^11.0.0
         version: 11.16.0(@trpc/server@11.16.0(typescript@5.9.3))(typescript@5.9.3)
@@ -699,6 +702,12 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@deno/shim-deno-test@0.5.0':
+    resolution: {integrity: sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==}
+
+  '@deno/shim-deno@0.18.2':
+    resolution: {integrity: sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==}
 
   '@dotenvx/dotenvx@1.60.1':
     resolution: {integrity: sha512-pPKqhE/HiaPDfbSf6doJnxeqzLszWP4eLICB89wRDZGaBaLzGpa3RgahVYIauBonaEWT8oxqAyacWKHtD+n3hQ==}
@@ -1582,6 +1591,14 @@ packages:
     version: 3.0.0
     engines: {node: '>=20'}
     peerDependencies:
+      zod: ^3.24.0
+
+  '@krdn/tickerlens@0.1.0':
+    resolution: {integrity: sha512-T97bIokgOvFjTR7hXbMbsy5b8757ovlAZXe746XbPNiarQsF4kcmR2X7SobeMdfYl2EIZMJpCVP2ftraX7Yxgg==}
+    version: 0.1.0
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@krdn/llm-gateway': ^3.0.0
       zod: ^3.24.0
 
   '@kwsites/file-exists@1.1.1':
@@ -3888,6 +3905,10 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -4125,6 +4146,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  fetch-mock-cache@2.3.1:
+    resolution: {integrity: sha512-hDk+Nbt0Y8Aq7KTEU6ASQAcpB34UjhkpD3QjzD6yvEKP4xVElAqXrjQ7maL+LYMGafx51Zq6qUfDM57PNu/qMw==}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -4135,6 +4159,18 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  filename-reserved-regex@2.0.0:
+    resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
+    engines: {node: '>=4'}
+
+  filenamify-url@2.1.2:
+    resolution: {integrity: sha512-3rMbAr7vDNMOGsj1aMniQFl749QjgM+lMJ/77ZRSPTIgxvolZwoQbn8dXLs7xfd+hAdli+oTnSWZNkJJLWQFEQ==}
+    engines: {node: '>=8'}
+
+  filenamify@4.3.0:
+    resolution: {integrity: sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==}
+    engines: {node: '>=8'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -4457,6 +4493,10 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  humanize-url@2.1.1:
+    resolution: {integrity: sha512-V4nxsPGNE7mPjr1qDp471YfW8nhBiTRWrG/4usZlpvFU8I7gsV7Jvrrzv/snbLm5dWO3dr1ennu2YqnhTWFmYA==}
+    engines: {node: '>=8'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -5342,6 +5382,10 @@ packages:
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  normalize-url@4.5.1:
+    resolution: {integrity: sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==}
+    engines: {node: '>=8'}
 
   normalize-url@8.1.1:
     resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
@@ -6270,6 +6314,10 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  strip-outer@1.0.1:
+    resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
+    engines: {node: '>=0.10.0'}
+
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
@@ -6382,8 +6430,15 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
   tldts-core@7.0.28:
     resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
 
   tldts@7.0.28:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
@@ -6400,6 +6455,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
 
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
@@ -6422,6 +6481,10 @@ packages:
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trim-repeated@1.0.0:
+    resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
+    engines: {node: '>=0.10.0'}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
@@ -6796,6 +6859,10 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yahoo-finance2@2.14.0:
+    resolution: {integrity: sha512-N559NorNMCa8lNeDISzc1vhZpc07UkP2WBNSLOs9S6jvAsIMYKyfUh/Gjunfzue3yh/1F5Jut2OdxtmfQZpI5w==}
+    engines: {node: '>=20.0.0'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -7224,6 +7291,13 @@ snapshots:
   '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.4.1': {}
+
+  '@deno/shim-deno-test@0.5.0': {}
+
+  '@deno/shim-deno@0.18.2':
+    dependencies:
+      '@deno/shim-deno-test': 0.5.0
+      which: 4.0.0
 
   '@dotenvx/dotenvx@1.60.1':
     dependencies:
@@ -7974,6 +8048,14 @@ snapshots:
       - supports-color
       - tree-sitter
       - utf-8-validate
+
+  '@krdn/tickerlens@0.1.0(@krdn/llm-gateway@https://codeload.github.com/krdn/llm-gateway/tar.gz/41911cd015aca1d7b9735f33902632ec078ada64(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.1))(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@krdn/llm-gateway': https://codeload.github.com/krdn/llm-gateway/tar.gz/41911cd015aca1d7b9735f33902632ec078ada64(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.1))(zod@3.25.76)
+      yahoo-finance2: 2.14.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
@@ -10227,6 +10309,8 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@1.0.5: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -10555,6 +10639,13 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  fetch-mock-cache@2.3.1:
+    dependencies:
+      debug: 4.4.3
+      filenamify-url: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   fflate@0.8.2: {}
 
   figures@6.1.0:
@@ -10564,6 +10655,19 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  filename-reserved-regex@2.0.0: {}
+
+  filenamify-url@2.1.2:
+    dependencies:
+      filenamify: 4.3.0
+      humanize-url: 2.1.1
+
+  filenamify@4.3.0:
+    dependencies:
+      filename-reserved-regex: 2.0.0
+      strip-outer: 1.0.1
+      trim-repeated: 1.0.0
 
   fill-range@7.1.1:
     dependencies:
@@ -11021,6 +11125,10 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  humanize-url@2.1.1:
+    dependencies:
+      normalize-url: 4.5.1
 
   husky@9.1.7: {}
 
@@ -12079,6 +12187,8 @@ snapshots:
       hosted-git-info: 7.0.2
       semver: 7.7.4
       validate-npm-package-license: 3.0.4
+
+  normalize-url@4.5.1: {}
 
   normalize-url@8.1.1: {}
 
@@ -13221,6 +13331,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strip-outer@1.0.1:
+    dependencies:
+      escape-string-regexp: 1.0.5
+
   stubs@3.0.0: {}
 
   style-to-js@1.1.21:
@@ -13349,7 +13463,13 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
   tldts-core@7.0.28: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   tldts@7.0.28:
     dependencies:
@@ -13362,6 +13482,10 @@ snapshots:
   toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
 
   tough-cookie@6.0.1:
     dependencies:
@@ -13379,6 +13503,10 @@ snapshots:
       node-gyp-build: 4.8.4
 
   trim-lines@3.0.1: {}
+
+  trim-repeated@1.0.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
 
   trough@2.2.0: {}
 
@@ -13770,6 +13898,14 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yahoo-finance2@2.14.0:
+    dependencies:
+      '@deno/shim-deno': 0.18.2
+      fetch-mock-cache: 2.3.1
+      tough-cookie: 5.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

`@krdn/tickerlens`를 사용해 미국 주식 티커를 **4 페르소나(Value/Growth/Quant/Options) × 3 타임프레임(Long/Mid/Short)**으로 분석하는 독립 페이지(`/stocks`)를 추가합니다.

- **packages/core**: `analyzeTicker` 래퍼 + 전용 `ModelConfigAdapter`. tickerlens가 자기 모듈 이름(`tickerlens.value.long` 등 16개)으로 `resolve`를 호출하는데 기존 `createModelConfigAdapter`는 모르는 이름에 throw하므로, 모듈 이름을 무시하고 고정 provider/model(`anthropic`/`claude-sonnet-4-6`)에 기존 `getProviderKeyInfo`의 복호화 키를 주입하는 전용 어댑터를 작성. 키 검증은 fail-fast(Yahoo 페치 전).
- **`stock_analyses` 테이블**: 분석 결과를 팀 공유 이력으로 저장(소유자 격리 없음, `requestedBy`는 실행자 표시용).
- **tRPC `stocks` 라우터**: `analyze`(동기 mutation, Zod 티커 검증, `meta.completed===0` 전체 실패 처리) / `list` / `getById`.
- **UI 6개 컴포넌트**: 페르소나별 그룹핑 그리드, 시그널 배지, 스냅샷 카드, 티커 입력(depth 토글), 이력 패널.
- **next.config**: `@krdn/tickerlens`/`yahoo-finance2`를 `serverExternalPackages`에 추가(클라이언트 번들 격리).

설계·계획 문서: `docs/superpowers/specs/2026-05-29-tickerlens-widget-design.md`, `docs/superpowers/plans/2026-05-29-tickerlens-widget.md`

## ⚠️ 배포 전 필수 조치

- [ ] **`pnpm db:push` 실행** — 개발/운영 공유 DB에 `stock_analyses` 테이블 생성. 누락 시 `/stocks` 분석 요청이 `relation "stock_analyses" does not exist`로 즉시 실패. (일반 PG 테이블이므로 `db:migrate-timescale`은 불필요.)
- [ ] **`anthropic` 프로바이더 키 등록 확인** — 키 미설정 시 분석이 "프로바이더 키가 설정되지 않았습니다" 에러로 실패(의도된 fail-fast).

## Test Plan

- [x] 신규 단위 테스트 11개 PASS (analyze-ticker 4, stocks 라우터 5, signal-badge 2)
- [x] `pnpm build` 성공 — `/stocks` 라우트 정적 생성, tickerlens/yahoo-finance2 번들링 에러 없음
- [x] `pnpm lint` 신규 파일 에러 없음
- [ ] `db:push` 후 실제 티커(예: AAPL) 분석 실행 → 페르소나별 그리드 표시 (개발 환경에서 확인 필요)
- [ ] 이력 항목 클릭 → `getById` 재표시
- [ ] 잘못된 티커 형식 거부, 일부 슬롯 실패 시 부분 렌더

🤖 Generated with [Claude Code](https://claude.com/claude-code)