### PR TITLE
fix: Playwright chromium 고아 프로세스 누수 해결

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -33,6 +33,8 @@ services:
       target: worker
     container_name: ais-prod-worker
     restart: unless-stopped
+    # PID 1 init이 고아 프로세스를 reap — 워커 비정상 종료(OOM kill 등) 시 chromium 잔존 방지
+    init: true
     stop_grace_period: 60s
     env_file:
       - ../.env.production
@@ -140,6 +142,8 @@ services:
     container_name: ais-collector-worker
     command: ["tsx", "apps/collector/src/queue/worker-process.ts"]
     restart: unless-stopped
+    # PID 1 init이 고아 프로세스를 reap — 워커 비정상 종료(OOM kill 등) 시 chromium 잔존 방지
+    init: true
     stop_grace_period: 60s
     mem_limit: 6g
     memswap_limit: 6g
@@ -210,6 +214,8 @@ services:
       dockerfile: apps/whisper-worker/Dockerfile
     container_name: ais-whisper-worker
     restart: unless-stopped
+    # PID 1 init이 고아 프로세스를 reap — yt-dlp/python3 자식 프로세스 잔존 방지
+    init: true
     stop_grace_period: 60s
     env_file:
       - ../.env.production

--- a/packages/collectors/src/adapters/browser-collector.ts
+++ b/packages/collectors/src/adapters/browser-collector.ts
@@ -24,7 +24,8 @@ export abstract class BrowserCollector<T> implements Collector<T> {
       const page = await context.newPage();
       yield* this.doCollect(page, options);
     } finally {
-      if (browser) await browser.close();
+      // close 실패가 doCollect의 원래 에러를 덮어쓰지 않도록 무시
+      if (browser) await browser.close().catch(() => {});
     }
   }
 

--- a/packages/collectors/src/adapters/naver-news.ts
+++ b/packages/collectors/src/adapters/naver-news.ts
@@ -210,6 +210,32 @@ export class NaverNewsCollector implements Collector<NaverArticle> {
     const pw: { browser: Browser | null; page: Page | null } = { browser: null, page: null };
     let fetchFailCount = 0;
 
+    // 폴백 브라우저 단일 비행(single-flight) 초기화.
+    // 동시 태스크가 각자 launchBrowser()를 호출하면 마지막 할당 외의 브라우저 핸들이
+    // 유실되어 close 불가 → chromium 고아 프로세스 누수. init promise 공유로 1회만 launch.
+    let pwInit: Promise<void> | null = null;
+    const ensurePlaywrightFallback = (): Promise<void> => {
+      pwInit ??= (async () => {
+        const browser = await launchBrowser();
+        // launch 직후 즉시 할당 — 이후 단계가 실패해도 finally에서 close 보장
+        pw.browser = browser;
+        try {
+          const context = await createBrowserContext(browser);
+          pw.page = await context.newPage();
+        } catch (err) {
+          pw.browser = null;
+          pw.page = null;
+          await browser.close().catch(() => {});
+          throw err;
+        }
+        console.warn(`naver-news fetch ${fetchFailCount}회 실패 → Playwright 폴백 활성화`);
+      })().catch((err: unknown) => {
+        pwInit = null; // 실패 시 다음 기사에서 재시도 가능
+        throw err;
+      });
+      return pwInit;
+    };
+
     // 세마포어: 외부 의존성 없이 동시성 제어
     let running = 0;
     const waitQueue: (() => void)[] = [];
@@ -239,12 +265,9 @@ export class NaverNewsCollector implements Collector<NaverArticle> {
             if (totalCollected >= maxItems) return null;
             await acquire();
             try {
-              // fetch 연속 실패 시 Playwright 폴백 준비 (lazy init)
-              if (fetchFailCount >= FETCH_FAIL_THRESHOLD && !pw.browser) {
-                pw.browser = await launchBrowser();
-                const context = await createBrowserContext(pw.browser);
-                pw.page = await context.newPage();
-                console.warn(`naver-news fetch ${fetchFailCount}회 실패 → Playwright 폴백 활성화`);
+              // fetch 연속 실패 시 Playwright 폴백 준비 (lazy init, 단일 비행)
+              if (fetchFailCount >= FETCH_FAIL_THRESHOLD) {
+                await ensurePlaywrightFallback();
               }
 
               const _commentsOnly = refetchCommentsOnlySet.has(article.url);
@@ -274,7 +297,8 @@ export class NaverNewsCollector implements Collector<NaverArticle> {
         }
       }
     } finally {
-      if (pw.browser) await pw.browser.close();
+      // close 실패가 수집 결과나 진행 중 에러를 덮어쓰지 않도록 무시
+      if (pw.browser) await pw.browser.close().catch(() => {});
     }
   }
 

--- a/packages/collectors/tests/naver-news-browser-leak.test.ts
+++ b/packages/collectors/tests/naver-news-browser-leak.test.ts
@@ -1,0 +1,136 @@
+// Playwright 폴백 브라우저 누수 회귀 테스트
+// fetch 연속 실패로 폴백이 켜질 때 동시 태스크가 각자 launchBrowser()를 호출해
+// 마지막 할당 외의 브라우저가 close되지 않고 chromium 고아 프로세스로 남는 버그 재현.
+//
+// ⚠️ 레이스 재현은 naver-news.ts 내부 상수에 의존:
+//   ARTICLE_CONCURRENCY=5, FETCH_FAIL_THRESHOLD=5, BATCH_SIZE=10
+//   (1차 웨이브 5건 전부 fetch 실패 → 2차 웨이브 5건이 동시에 폴백 진입)
+//   상수가 바뀌어 동시 폴백 진입 태스크가 2개 미만이 되면 이 테스트의 레이스 검증력이 사라진다.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NaverNewsCollector } from '../src/adapters/naver-news';
+import { launchBrowser, createBrowserContext } from '../src/utils/browser';
+
+const { browserState } = vi.hoisted(() => ({
+  browserState: {
+    created: [] as Array<{ closed: boolean }>,
+    reset() {
+      this.created = [];
+    },
+  },
+}));
+
+vi.mock('../src/utils/browser', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/utils/browser')>();
+  return {
+    ...original,
+    // 실제 launch처럼 시간이 걸리도록 지연 — check-then-act 레이스 재현 조건
+    launchBrowser: vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      const fake = {
+        closed: false,
+        close: async () => {
+          fake.closed = true;
+        },
+      };
+      browserState.created.push(fake);
+      return fake as unknown as import('playwright').Browser;
+    }),
+    createBrowserContext: vi.fn(async () => ({
+      newPage: async () => ({
+        goto: async () => {
+          throw new Error('nav fail (test)');
+        },
+        waitForTimeout: async () => {},
+        content: async () => '<html></html>',
+      }),
+    })),
+    sleep: vi.fn(async () => {}),
+  };
+});
+
+/** 검색 결과 fixture — 1차 셀렉터(sds-comps headline1) 경로로 파싱되는 기사 N건 */
+function buildSearchFixture(count: number): string {
+  const items = Array.from({ length: count }, (_, i) => {
+    const aid = String(i + 1).padStart(10, '0');
+    return `<div class="item">
+      <a href="https://n.news.naver.com/article/001/${aid}">
+        <span class="sds-comps-text-type-headline1">테스트 기사 제목 ${i + 1}번</span>
+      </a>
+      <img alt="연합뉴스의 프로필 이미지" />
+    </div>`;
+  }).join('\n');
+  return `<html><body>${items}</body></html>`;
+}
+
+function stubFetch(fixtureCount: number): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes('search.naver.com')) {
+        // 1페이지(start=1)만 fixture 반환 — start=11 등 후속 페이지와 혼동 방지 위해 정확 비교
+        const start = new URL(url).searchParams.get('start');
+        const html = start === '1' ? buildSearchFixture(fixtureCount) : '<html></html>';
+        return new Response(html, { status: 200 });
+      }
+      // 기사 본문 fetch는 전부 실패 → FETCH_FAIL_THRESHOLD 도달 → Playwright 폴백 활성화
+      throw new Error('article fetch fail (test)');
+    }),
+  );
+}
+
+async function collectAll(maxItems: number): Promise<unknown[]> {
+  const collector = new NaverNewsCollector();
+  const items: unknown[] = [];
+  for await (const chunk of collector.collect({
+    keyword: '테스트',
+    startDate: '2026-06-09T00:00:00.000Z',
+    endDate: '2026-06-09T00:00:00.000Z',
+    maxItems,
+  })) {
+    items.push(...chunk);
+  }
+  return items;
+}
+
+describe('NaverNewsCollector Playwright 폴백 브라우저 정리', () => {
+  beforeEach(() => {
+    browserState.reset();
+    vi.mocked(launchBrowser).mockClear();
+    vi.mocked(createBrowserContext).mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('폴백 활성화 시 launchBrowser는 1회만 호출되고 모든 브라우저가 close된다', async () => {
+    stubFetch(10);
+    const items = await collectAll(10);
+
+    // 수집 자체는 진행됨 (본문 null이어도 기사 yield)
+    expect(items.length).toBeGreaterThan(0);
+    // 폴백 브라우저는 정확히 1개만 launch되어야 함 (동시 태스크 단일 비행 보장)
+    expect(launchBrowser).toHaveBeenCalledTimes(1);
+    // 생성된 모든 브라우저는 close되어야 함 — 누수 0 보장
+    const leaked = browserState.created.filter((b) => !b.closed);
+    expect(leaked).toHaveLength(0);
+  });
+
+  it('폴백 init 실패 시 부분 생성 브라우저를 close하고 다음 배치에서 재시도한다', async () => {
+    stubFetch(15); // 배치 1(10건: 웨이브1 실패 누적 + 웨이브2 폴백 init 실패) + 배치 2(5건: 재시도 성공)
+    vi.mocked(createBrowserContext).mockImplementationOnce(async () => {
+      throw new Error('context fail (test)');
+    });
+
+    const items = await collectAll(15);
+
+    expect(items).toHaveLength(15);
+    // 1차 init 실패 후 pwInit 리셋 → 다음 배치에서 재시도 = launch 정확히 2회
+    expect(launchBrowser).toHaveBeenCalledTimes(2);
+    expect(browserState.created).toHaveLength(2);
+    // 실패한 init의 부분 생성 브라우저 포함 전부 close — 누수 0 보장
+    const leaked = browserState.created.filter((b) => !b.closed);
+    expect(leaked).toHaveLength(0);
+  });
+});

--- a/packages/core/src/report/pdf-exporter.ts
+++ b/packages/core/src/report/pdf-exporter.ts
@@ -15,15 +15,19 @@ export async function exportToPdf(
   const html = buildHtmlFromMarkdown(markdownContent, options.title ?? '분석 리포트');
 
   const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.setContent(html, { waitUntil: 'networkidle' });
-  await page.pdf({
-    path: outputPath,
-    format: options.format ?? 'A4',
-    margin: options.margin ?? { top: '20mm', bottom: '20mm', left: '15mm', right: '15mm' },
-    printBackground: true,
-  });
-  await browser.close();
+  try {
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'networkidle' });
+    await page.pdf({
+      path: outputPath,
+      format: options.format ?? 'A4',
+      margin: options.margin ?? { top: '20mm', bottom: '20mm', left: '15mm', right: '15mm' },
+      printBackground: true,
+    });
+  } finally {
+    // 렌더링/PDF 단계 예외 시에도 chromium 프로세스 누수 방지. close 실패는 원래 에러를 덮지 않도록 무시.
+    await browser.close().catch(() => {});
+  }
 }
 
 /**

--- a/packages/core/tests/pdf-exporter.test.ts
+++ b/packages/core/tests/pdf-exporter.test.ts
@@ -1,0 +1,61 @@
+// PDF 내보내기 브라우저 누수 회귀 테스트
+// page.setContent/pdf 단계에서 예외가 나도 browser.close()가 보장되어야 한다.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { exportToPdf } from '../src/report/pdf-exporter';
+
+const { state } = vi.hoisted(() => ({
+  state: { launched: 0, closed: 0, pdfShouldFail: false, closeShouldFail: false },
+}));
+
+vi.mock('playwright', () => ({
+  chromium: {
+    launch: vi.fn(async () => {
+      state.launched++;
+      return {
+        newPage: async () => ({
+          setContent: async () => {},
+          pdf: async () => {
+            if (state.pdfShouldFail) throw new Error('pdf fail (test)');
+          },
+        }),
+        close: async () => {
+          state.closed++;
+          if (state.closeShouldFail) throw new Error('close fail (test)');
+        },
+      };
+    }),
+  },
+}));
+
+describe('exportToPdf 브라우저 정리', () => {
+  beforeEach(() => {
+    state.launched = 0;
+    state.closed = 0;
+    state.pdfShouldFail = false;
+    state.closeShouldFail = false;
+  });
+
+  it('정상 완료 시 브라우저가 close된다', async () => {
+    await exportToPdf('# 제목\n\n본문', '/tmp/pdf-exporter-test.pdf');
+    expect(state.launched).toBe(1);
+    expect(state.closed).toBe(1);
+  });
+
+  it('PDF 생성 실패 시에도 브라우저가 close된다 (누수 방지)', async () => {
+    state.pdfShouldFail = true;
+    await expect(exportToPdf('# 제목', '/tmp/pdf-exporter-test.pdf')).rejects.toThrow(
+      'pdf fail (test)',
+    );
+    expect(state.launched).toBe(1);
+    expect(state.closed).toBe(1);
+  });
+
+  it('close 실패가 원래 PDF 에러를 덮어쓰지 않는다', async () => {
+    state.pdfShouldFail = true;
+    state.closeShouldFail = true;
+    await expect(exportToPdf('# 제목', '/tmp/pdf-exporter-test.pdf')).rejects.toThrow(
+      'pdf fail (test)',
+    );
+    expect(state.closed).toBe(1);
+  });
+});


### PR DESCRIPTION
## 문제

운영 컨테이너에서 새벽 5시 수집 이후 Playwright chromium 프로세스(각 ~210MB)가 수 시간 잔존·누적되는 메모리 누수. 컨테이너 메모리 8GB 상향으로도 부족했던 원인.

## 근본 원인

`naver-news.ts` Phase 2 본문 수집의 Playwright 폴백 lazy init이 check-then-act 레이스:

- `ARTICLE_CONCURRENCY=5` 동시 태스크가 모두 `!pw.browser`(null) 체크 통과 → 각자 `launchBrowser()`
- `pw.browser`에는 마지막 할당만 남아 **최대 4개 브라우저 핸들 유실** → finally의 close가 1개만 정리
- fetch 연속 실패(네이버 차단) 시에만 발화 → 새벽 수집 시간대와 일치

## 수정

| 파일 | 내용 |
|---|---|
| `naver-news.ts` | 폴백 초기화 single-flight(pwInit promise 공유) — launch 정확히 1회. init 실패 시 부분 브라우저 close + 다음 배치 재시도 |
| `pdf-exporter.ts` | try/finally로 `browser.close()` 보장 (예외 시 누수되던 잠재 결함) |
| `browser-collector.ts` | finally close 실패가 doCollect 원래 에러를 덮지 않도록 보강 |
| `docker-compose.prod.yml` | worker/collector-worker/whisper-worker에 `init: true` — OOM kill 등 비정상 종료 시 고아 프로세스 reap |

## 검증

- [x] TDD: 수정 전 코드에서 회귀 테스트가 **launch 5회 호출(핸들 4개 유실)로 결정적 실패** 확인 → 수정 후 GREEN
- [x] 신규 회귀 테스트 2파일 5케이스 (single-flight, init 실패 재시도, close 보장, 에러 보존)
- [x] collectors 110개 / core 502개 테스트 통과 (day-window 7건은 로컬 chromium 바이너리 부재로 인한 기존 환경 실패)
- [x] 두 패키지 tsc 빌드 통과, ESLint 신규 이슈 0건
- [x] 3관점 적대적 검증(레이스 정합성/리포 전체 누수 경로 스윕/테스트 유효성) 통과 — chromium launch 지점은 리포 전체 3곳뿐, 모두 정리 보장 확인

## 배포 후

임시 chromium 정리 cron 제거 예정.