### PR TITLE
fix: 모니터 stalled 목록의 (runId, source) 중복 노출 해결

### DIFF
--- a/apps/collector/src/queue/executor.ts
+++ b/apps/collector/src/queue/executor.ts
@@ -42,6 +42,43 @@ const INLINE_COMMENT_SOURCES: ReadonlySet<CollectorSource> = new Set<CollectorSo
 ]);
 
 /**
+ * (runId, source)의 running 행을 보장 — 있으면 재사용, 없으면 생성.
+ *
+ * 워커가 finalize 없이 죽은 뒤(배포 재시작, OOM kill) startup-recovery가
+ * 같은 run을 재실행할 때 무조건 INSERT하면 running 행이 중복으로 쌓여
+ * 모니터 stalled 목록에 같은 (runId, source)가 두 번 노출된다.
+ */
+export async function ensureRunningRun(params: {
+  runId: string;
+  subscriptionId: number;
+  source: string;
+  triggerType: CollectionJobData['triggerType'];
+}): Promise<void> {
+  const db = getDb();
+  const reused = await db
+    .update(collectionRuns)
+    .set({ lastProgressAt: new Date() })
+    .where(
+      and(
+        eq(collectionRuns.runId, params.runId),
+        eq(collectionRuns.source, params.source),
+        eq(collectionRuns.status, 'running'),
+      ),
+    )
+    .returning({ runId: collectionRuns.runId });
+  if (reused.length > 0) return;
+
+  await db.insert(collectionRuns).values({
+    time: new Date(),
+    runId: params.runId,
+    subscriptionId: params.subscriptionId,
+    source: params.source,
+    status: 'running',
+    triggerType: params.triggerType,
+  });
+}
+
+/**
  * texts 전체를 EMBED_BATCH_SIZE로 쪼개 embedPassages를 여러 번 호출한다.
  * 실패하는 배치가 있으면 그 배치 구간만 빈 배열로 채워 전체 길이를 유지한다.
  */
@@ -109,14 +146,7 @@ export async function executeCollectionJob(
   const db = getDb();
   const startedAt = Date.now();
 
-  await db.insert(collectionRuns).values({
-    time: new Date(),
-    runId,
-    subscriptionId,
-    source,
-    status: 'running',
-    triggerType,
-  });
+  await ensureRunningRun({ runId, subscriptionId, source, triggerType });
 
   let itemsCollected = 0;
   let itemsNew = 0;
@@ -466,14 +496,7 @@ async function executeCommentsJob(job: Job<CollectionJobData>): Promise<Collecti
     return { runId, itemsCollected: 0, itemsNew: 0, blocked: false, durationMs: 0 };
   }
 
-  await db.insert(collectionRuns).values({
-    time: new Date(),
-    runId,
-    subscriptionId,
-    source,
-    status: 'running',
-    triggerType,
-  });
+  await ensureRunningRun({ runId, subscriptionId, source, triggerType });
 
   let itemsCollected = 0;
   let itemsNew = 0;

--- a/apps/collector/src/queue/run-row-idempotency.integration.test.ts
+++ b/apps/collector/src/queue/run-row-idempotency.integration.test.ts
@@ -1,0 +1,67 @@
+// ensureRunningRun 멱등성 통합 테스트
+// 워커 강제 종료 후 startup-recovery 재실행 시 collection_runs에 같은
+// (runId, source) running 행이 중복 INSERT되던 버그의 회귀 방지.
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb } from '../db';
+import { collectionRuns, keywordSubscriptions } from '../db/schema';
+import { ensureRunningRun } from './executor';
+
+const SOURCE = 'naver-comments';
+
+describe('ensureRunningRun', () => {
+  let subId: number;
+  const runIds: string[] = [];
+
+  beforeEach(async () => {
+    const [sub] = await getDb()
+      .insert(keywordSubscriptions)
+      .values({
+        keyword: 'run-row-idem-test',
+        sources: ['naver-news'],
+        intervalHours: 6,
+        limits: { maxPerRun: 10 },
+      })
+      .returning();
+    subId = sub.id;
+  });
+
+  afterEach(async () => {
+    for (const rid of runIds) {
+      await getDb().delete(collectionRuns).where(eq(collectionRuns.runId, rid));
+    }
+    runIds.length = 0;
+    await getDb().delete(keywordSubscriptions).where(eq(keywordSubscriptions.id, subId));
+  });
+
+  it('running 행이 없으면 생성하고, 재호출(재실행 시뮬레이션) 시 재사용한다', async () => {
+    const runId = randomUUID();
+    runIds.push(runId);
+    const params = { runId, subscriptionId: subId, source: SOURCE, triggerType: 'manual' as const };
+
+    await ensureRunningRun(params);
+    await ensureRunningRun(params); // startup-recovery 재실행 시뮬레이션
+
+    const rows = await getDb().select().from(collectionRuns).where(eq(collectionRuns.runId, runId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('running');
+  });
+
+  it('이전 행이 finalize된 뒤에는 새 running 행을 생성한다 (재시도 이력 보존)', async () => {
+    const runId = randomUUID();
+    runIds.push(runId);
+    const params = { runId, subscriptionId: subId, source: SOURCE, triggerType: 'manual' as const };
+
+    await ensureRunningRun(params);
+    await getDb()
+      .update(collectionRuns)
+      .set({ status: 'failed' })
+      .where(eq(collectionRuns.runId, runId));
+    await ensureRunningRun(params);
+
+    const rows = await getDb().select().from(collectionRuns).where(eq(collectionRuns.runId, runId));
+    expect(rows).toHaveLength(2);
+    expect(rows.filter((r) => r.status === 'running')).toHaveLength(1);
+  });
+});

--- a/apps/collector/src/server/trpc/runs.ts
+++ b/apps/collector/src/server/trpc/runs.ts
@@ -7,6 +7,7 @@ import { getCollectQueue } from '../../queue/queues';
 import { COLLECTOR_SOURCES } from '../../queue/types';
 import type { CollectorSource } from '../../queue/types';
 import { protectedProcedure, router } from './init';
+import { dedupeLatestRunRows } from './stalled-dedupe';
 
 const SOURCE_ENUM = [
   'naver-news',
@@ -329,7 +330,8 @@ export const runsRouter = router({
         )
         .orderBy(desc(collectionRuns.time))
         .limit(50);
-      return rows;
+      // 비정상 종료 잔재로 같은 (runId, source) running 행이 중복될 수 있음 — 최신 행만 노출
+      return dedupeLatestRunRows(rows);
     }),
 
   forceComplete: protectedProcedure

--- a/apps/collector/src/server/trpc/stalled-dedupe.test.ts
+++ b/apps/collector/src/server/trpc/stalled-dedupe.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { dedupeLatestRunRows } from './stalled-dedupe';
+
+describe('dedupeLatestRunRows', () => {
+  it('같은 (runId, source) 중복 시 최신(앞쪽) 행만 남긴다', () => {
+    const rows = [
+      { runId: 'a', source: 'naver-comments', time: new Date('2026-06-10T08:00:00Z') },
+      { runId: 'a', source: 'naver-comments', time: new Date('2026-06-10T05:00:00Z') },
+      { runId: 'a', source: 'naver-news', time: new Date('2026-06-10T05:00:00Z') },
+    ];
+
+    const result = dedupeLatestRunRows(rows);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].time.toISOString()).toBe('2026-06-10T08:00:00.000Z');
+    expect(result.map((r) => `${r.runId}-${r.source}`)).toEqual([
+      'a-naver-comments',
+      'a-naver-news',
+    ]);
+  });
+
+  it('중복이 없으면 그대로 반환', () => {
+    const rows = [
+      { runId: 'a', source: 'naver-news' },
+      { runId: 'b', source: 'naver-news' },
+      { runId: 'a', source: 'youtube' },
+    ];
+    expect(dedupeLatestRunRows(rows)).toHaveLength(3);
+  });
+
+  it('빈 배열은 빈 배열 반환', () => {
+    expect(dedupeLatestRunRows([])).toEqual([]);
+  });
+});

--- a/apps/collector/src/server/trpc/stalled-dedupe.ts
+++ b/apps/collector/src/server/trpc/stalled-dedupe.ts
@@ -1,0 +1,18 @@
+/**
+ * stalled run 목록의 (runId, source) 중복 제거.
+ *
+ * 워커 강제 종료(배포 재시작 등) 후 startup-recovery가 같은 run을 재실행하면
+ * collection_runs에 동일 (runId, source)의 running 행이 중복으로 남을 수 있다.
+ * 모니터 UI는 (runId, source)를 React key로 쓰므로 최신 행 하나만 노출한다.
+ *
+ * 입력은 time DESC 정렬을 전제로 하며, 같은 키의 첫 번째(=최신) 행을 유지한다.
+ */
+export function dedupeLatestRunRows<T extends { runId: string; source: string }>(rows: T[]): T[] {
+  const seen = new Set<string>();
+  return rows.filter((r) => {
+    const key = `${r.runId} ${r.source}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}


### PR DESCRIPTION
## 문제

모니터 페이지 `StalledRunsBanner`에서 React 중복 key 오류:
`Encountered two children with the same key, '63113381-...-naver-comments'`

## 근본 원인

워커가 finalize 없이 강제 종료된 뒤(배포 재시작, OOM kill) `startup-recovery`가 같은 run을 새 jobId로 재큐잉하면, executor의 두 실행 경로(일반 소스/naver-comments) 모두 **무조건 INSERT**라서 `collection_runs`에 동일 `(runId, source)`의 `running` 행이 중복으로 쌓임. `runs.stalled` 쿼리는 행을 그대로 반환하므로 UI key(`runId-source`)가 충돌.

오늘 chromium 누수 수정 배포(#149)로 collector-worker가 재시작되며 진행 중이던 naver-comments 잡이 재실행된 것이 직접 트리거.

## 수정

| 파일 | 내용 |
|---|---|
| `queue/executor.ts` | running 행 생성을 `ensureRunningRun`으로 멱등화 — 같은 (runId, source)의 running 행이 있으면 재사용(lastProgressAt 갱신), finalize된 뒤에만 새 행 생성(재시도 이력 보존) |
| `server/trpc/runs.ts` | stalled 응답에서 잔존 중복 행은 최신 행만 노출 (`dedupeLatestRunRows`) — 이미 쌓인 중복 데이터에 대한 방어선 |

## 검증

- [x] 단위 테스트 3건 (dedupe 동작)
- [x] 통합 테스트 2건 (`TEST_MODE=integration`, dev TimescaleDB) — 재실행 시 행 재사용 / finalize 후 새 행 생성
- [x] collector 단위 103건 통과, tsc 빌드 클린, ESLint 신규 이슈 0건