### PR TITLE
fix: 수집 워커 유령 실행 릴레이·OOM 크래시 해소

### DIFF
--- a/apps/collector/src/queue/cancellation-guard.integration.test.ts
+++ b/apps/collector/src/queue/cancellation-guard.integration.test.ts
@@ -1,0 +1,54 @@
+// isCancellationRequested 통합 테스트 — startup-recovery 재큐잉 가드의 핵심 조회.
+// 취소된 run이 워커 재시작마다 재큐잉→즉시 취소 실패를 반복하던 루프의 회귀 방지.
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, afterEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb } from '../db';
+import { runCancellations } from '../db/schema';
+import { isCancellationRequested } from './cancellation';
+
+const SOURCE = 'naver-news';
+
+describe('isCancellationRequested', () => {
+  const runIds: string[] = [];
+
+  afterEach(async () => {
+    for (const rid of runIds) {
+      await getDb().delete(runCancellations).where(eq(runCancellations.runId, rid));
+    }
+    runIds.length = 0;
+  });
+
+  it('취소 요청이 없으면 false', async () => {
+    const runId = randomUUID();
+    expect(await isCancellationRequested(runId, SOURCE)).toBe(false);
+  });
+
+  it('cancelling 상태면 true', async () => {
+    const runId = randomUUID();
+    runIds.push(runId);
+    await getDb().insert(runCancellations).values({
+      runId,
+      source: SOURCE,
+      status: 'cancelling',
+      mode: 'force',
+      triggeredBy: 'integration-test',
+    });
+    expect(await isCancellationRequested(runId, SOURCE)).toBe(true);
+  });
+
+  it('cancelled(최종) 상태면 true, 다른 source는 false', async () => {
+    const runId = randomUUID();
+    runIds.push(runId);
+    await getDb().insert(runCancellations).values({
+      runId,
+      source: SOURCE,
+      status: 'cancelled',
+      mode: 'graceful',
+      triggeredBy: 'integration-test',
+      finalizedAt: new Date(),
+    });
+    expect(await isCancellationRequested(runId, SOURCE)).toBe(true);
+    expect(await isCancellationRequested(runId, 'youtube')).toBe(false);
+  });
+});

--- a/apps/collector/src/queue/cancellation.ts
+++ b/apps/collector/src/queue/cancellation.ts
@@ -17,17 +17,24 @@ export class CancelledError extends Error {
 }
 
 /**
- * worker의 단계/배치 시작부에서 호출. cancelling/cancelled이면 CancelledError throw.
- * BullMQ 외부 force cancel만으로는 실행 중인 processor를 멈출 수 없으므로,
- * 이 함수가 유일한 cooperative 중단 신호다 (Task 0 검증).
+ * cancelling/cancelled 여부를 throw 없이 조회 — startup-recovery 재큐잉 가드 등에 사용.
  */
-export async function checkCancellation(runId: string, source: string): Promise<void> {
+export async function isCancellationRequested(runId: string, source: string): Promise<boolean> {
   const [row] = await getDb()
     .select()
     .from(runCancellations)
     .where(and(eq(runCancellations.runId, runId), eq(runCancellations.source, source)))
     .limit(1);
-  if (row && (row.status === 'cancelling' || row.status === 'cancelled')) {
+  return !!row && (row.status === 'cancelling' || row.status === 'cancelled');
+}
+
+/**
+ * worker의 단계/배치 시작부에서 호출. cancelling/cancelled이면 CancelledError throw.
+ * BullMQ 외부 force cancel만으로는 실행 중인 processor를 멈출 수 없으므로,
+ * 이 함수가 유일한 cooperative 중단 신호다 (Task 0 검증).
+ */
+export async function checkCancellation(runId: string, source: string): Promise<void> {
+  if (await isCancellationRequested(runId, source)) {
     throw new CancelledError(runId, source);
   }
 }

--- a/apps/collector/src/queue/startup-recovery.ts
+++ b/apps/collector/src/queue/startup-recovery.ts
@@ -14,6 +14,7 @@
 
 import { Queue } from 'bullmq';
 import { getBullMQOptions } from './connection';
+import { isCancellationRequested } from './cancellation';
 import { COLLECTOR_SOURCES, type CollectionJobData } from './types';
 
 export async function recoverOrphanedJobs(): Promise<void> {
@@ -30,15 +31,30 @@ export async function recoverOrphanedJobs(): Promise<void> {
       if (activeJobs.length === 0) continue;
 
       let recovered = 0;
+      let skipped = 0;
       for (const job of activeJobs) {
         if (!job || !job.data) continue;
+
+        // 취소 요청된 run은 재큐잉하지 않음 — 재실행→즉시 취소 실패가 재시작마다
+        // 반복되는 루프 방지 (취소된 run이 24h에 283행을 쌓던 사례).
+        if (await isCancellationRequested(job.data.runId, source)) {
+          await job.remove().catch(() => void 0);
+          skipped++;
+          continue;
+        }
 
         // processedOn이 있고 finishedOn이 없으면 orphan 후보.
         // active 상태 자체가 이미 processedOn 설정 이후이므로 중복 확인 불필요.
         try {
-          // 원본 job은 제거 — 같은 jobId로 재큐잉하면 충돌
-          await job.remove().catch(() => void 0);
+          // 원본 job 제거. lock이 아직 살아있으면(이전 실행이 유효하게 진행 중) throw —
+          // 이때 재큐잉하면 같은 run의 이중 실행이 되므로 stall 메커니즘에 맡기고 건너뛴다.
+          await job.remove();
+        } catch {
+          skipped++;
+          continue;
+        }
 
+        try {
           await queue.add(`collect-${source}`, job.data, {
             jobId: `${job.data.runId}-${source}-recovered-${Date.now()}`,
             attempts: 3,
@@ -53,6 +69,10 @@ export async function recoverOrphanedJobs(): Promise<void> {
             err instanceof Error ? err.message : err,
           );
         }
+      }
+
+      if (skipped > 0) {
+        console.log(`[startup-recovery] ${source}: ${skipped}개 skip (취소됨 또는 lock 유효)`);
       }
 
       if (recovered > 0) {

--- a/apps/collector/src/queue/worker-process.ts
+++ b/apps/collector/src/queue/worker-process.ts
@@ -50,15 +50,15 @@ function buildWorker(source: CollectorSource): Worker<CollectionJobData, Collect
   const opts: WorkerOptions = {
     ...getBullMQOptions(),
     concurrency: CONCURRENCY[source],
-    // 대량 수집(특히 youtube 수천건 댓글 + 임베딩)은 한 job이 수 분 이상 걸린다.
-    // BullMQ 기본 lockDuration=30s로는 CPU가 임베딩 추론에 점유될 때 갱신 실패 →
-    // "stalled" 오판으로 같은 job이 중복 재실행되거나 실패 기록됨.
-    // 5분으로 늘려 정상적으로 오래 걸리는 작업을 stalled로 오판하지 않도록 한다.
-    // YouTube 대량 수집(수천 건 비디오+댓글+임베딩)은 5분 이상 소요 가능.
-    // 10분으로 늘려 stalled 오판 방지.
-    lockDuration: 600_000,
-    // 2분마다 stall check — 10분 lockDuration의 1/5.
-    stalledInterval: 120_000,
+    // 임베딩(Xenova CPU 추론)이 이벤트 루프를 장시간 점유하면 lock 갱신이 밀린다.
+    // lockDuration이 실제 잡 시간(naver-comments 1만 댓글 = 30~50분)보다 짧으면
+    // BullMQ가 stalled로 오판해 같은 잡을 재배달하는데, 기존 실행은 죽지 않고 계속
+    // 돌아 이중 실행(유령 실행)이 릴레이처럼 이어진다 — 2026-06-10 분석: 한 run이
+    // 17일간 시간당 1~2회 재수집 루프를 돌며 OOM(exit 137) 크래시까지 유발.
+    // 최대 잡 시간보다 넉넉한 60분으로 설정. 워커 사망 시 복구는 startup-recovery 담당.
+    lockDuration: 3_600_000,
+    // 5분마다 stall check — 60분 lock에서 2분 체크는 과도.
+    stalledInterval: 300_000,
     // Worker 재시작 시 orphaned job 복구 허용. 수집은 멱등.
     maxStalledCount: 1,
     // 차단 방지: 작업 간 최소 간격 (ms). 소스별로 별도 튜닝 여지.

--- a/apps/collector/src/server/trpc/runs.ts
+++ b/apps/collector/src/server/trpc/runs.ts
@@ -326,7 +326,12 @@ export const runsRouter = router({
         .select()
         .from(collectionRuns)
         .where(
-          and(eq(collectionRuns.status, 'running'), sql`${collectionRuns.time} < ${threshold}`),
+          and(
+            eq(collectionRuns.status, 'running'),
+            // 진행 하트비트(last_progress_at) 기준으로 판정 — 시작시각(time) 기준이면
+            // 30분 넘게 정상 진행 중인 run도 전부 '멈춤 의심'으로 표시된다.
+            sql`COALESCE(${collectionRuns.lastProgressAt}, ${collectionRuns.time}) < ${threshold}`,
+          ),
         )
         .orderBy(desc(collectionRuns.time))
         .limit(50);

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -145,8 +145,9 @@ services:
     # PID 1 init이 고아 프로세스를 reap — 워커 비정상 종료(OOM kill 등) 시 chromium 잔존 방지
     init: true
     stop_grace_period: 60s
-    mem_limit: 6g
-    memswap_limit: 6g
+    # 임베딩(Xenova) + Playwright 동시 수행 시 6g에서 OOM kill(exit 137) 재발 — 8g로 상향
+    mem_limit: 8g
+    memswap_limit: 8g
     env_file:
       - ../.env.production
     environment:


### PR DESCRIPTION
## 배경 (운영 분석 2026-06-10)

collector-worker에서 3중 결함이 상호 증폭 중:

1. **유령 실행 릴레이**: naver-comments 1만 댓글 임베딩(Xenova CPU)이 이벤트 루프를 점유 → lockDuration(10분) 갱신 실패 → BullMQ stalled 오판으로 같은 잡 재배달 → 기존 JS 실행은 죽지 않고 병행. run `63113381`('한동훈')이 **5/24부터 17일간 시간당 1~2회 재수집**(collection_runs 행 2,716개), 신규 데이터 0.
2. **취소 루프**: 취소된 run의 잡을 startup-recovery가 재시작마다 새 jobId로 재큐잉 → 재실행→즉시 취소 실패 반복 (run `75ea3485` 24h에 283행).
3. **OOM 크래시**: 유령 실행 중첩으로 메모리 5.99/6GiB 도달 직후 **exit 137(SIGKILL)** — 실시간 감시로 확정. ~40분 주기 재시작이 recovery 재큐잉을 유발해 1·2를 증폭.

## 수정

| 파일 | 내용 |
|---|---|
| `worker-process.ts` | lockDuration 10분→**60분**, stalledInterval 2분→5분 — 정상 장시간 잡의 stalled 오판(릴레이 근원) 차단 |
| `startup-recovery.ts` | ① 취소 요청된 run 재큐잉 제외 ② `job.remove()` 실패(lock 유효 = 이전 실행 생존) 시 재큐잉 건너뜀 — 이중 실행 복제 경로 차단 |
| `cancellation.ts` | `isCancellationRequested` 비-throw 조회 추가, checkCancellation이 재사용 |
| `runs.ts` (stalled) | 판정 기준 `COALESCE(last_progress_at, time)` — 진행 중인 장시간 run의 거짓 '멈춤 의심' 제거 |
| `docker-compose.prod.yml` | collector-worker mem_limit 6g→8g |

## 검증

- [x] 통합 테스트 5건 통과 (isCancellationRequested 3건 신규 + ensureRunningRun 2건, dev TimescaleDB)
- [x] 단위 103건 통과, tsc 클린, ESLint 신규 오류 0 (경고는 기존 패턴과 동일 종류)
- [x] compose config 검증 통과

## 배포 후 계획

CD 자동 배포로 컨테이너 재생성 시 현재 살아있는 유령 실행 4개도 함께 소멸. 이후 좀비 running 행(4/24 run 포함) 일괄 finalize 정리 예정.