### PR TITLE
fix: DC 과거 윈도우 헛돌이·nextRunAt 기아·forceComplete 오버플로 해소

### DIFF
--- a/apps/collector/src/queue/executor.ts
+++ b/apps/collector/src/queue/executor.ts
@@ -9,6 +9,7 @@ import { classifySentimentFromTexts } from '../services/sentiment';
 import { CancelledError, checkCancellation, finalizeCancellationIfDone } from './cancellation';
 import { mapToRawItem } from './item-mapper';
 import { enqueueCollectionJob } from './queues';
+import { isStaleCatchupJob } from './stale-job';
 import type {
   CollectionJobData,
   CollectionJobResult,
@@ -406,12 +407,16 @@ export async function executeCollectionJob(
     }
 
     // subscription 상태 업데이트 (source 중 하나라도 완료되면 lastRunAt 갱신)
-    const nextRunAt = await computeNextRunAt(subscriptionId);
+    const { nextRunAt, intervalHours } = await computeNextRunAt(subscriptionId);
+    // 큐에 묵었다 늦게 실행된 백로그 잡의 완료가 nextRunAt을 미래로 밀면, 백로그가
+    // 소진될 때까지 스케줄러가 due를 보지 못해 현재 윈도우 잡 발급이 기아 상태가 된다
+    // (2026-06-11 dcinside 사례). 백로그 잡은 nextRunAt 갱신을 생략한다.
+    const staleCatchup = isStaleCatchupJob(dateRange.endISO, intervalHours);
     await db
       .update(keywordSubscriptions)
       .set({
         lastRunAt: new Date(),
-        nextRunAt,
+        ...(staleCatchup ? {} : { nextRunAt }),
         status: 'active',
         lastError: null,
       })
@@ -686,7 +691,9 @@ async function executeCommentsJob(job: Job<CollectionJobData>): Promise<Collecti
 /**
  * 다음 실행 시각 — subscription.intervalHours 기반.
  */
-async function computeNextRunAt(subscriptionId: number): Promise<Date> {
+async function computeNextRunAt(
+  subscriptionId: number,
+): Promise<{ nextRunAt: Date; intervalHours: number }> {
   const db = getDb();
   const [row] = await db
     .select({ intervalHours: keywordSubscriptions.intervalHours })
@@ -694,7 +701,7 @@ async function computeNextRunAt(subscriptionId: number): Promise<Date> {
     .where(eq(keywordSubscriptions.id, subscriptionId))
     .limit(1);
   const hours = row?.intervalHours ?? 6;
-  return new Date(Date.now() + hours * 3600 * 1000);
+  return { nextRunAt: new Date(Date.now() + hours * 3600 * 1000), intervalHours: hours };
 }
 
 // sql import used implicitly by drizzle query builders above — suppress unused

--- a/apps/collector/src/queue/stale-job.test.ts
+++ b/apps/collector/src/queue/stale-job.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { isStaleCatchupJob } from './stale-job';
+
+describe('isStaleCatchupJob', () => {
+  const H = 3600_000;
+  const now = Date.parse('2026-06-11T00:00:00Z');
+
+  it('윈도우 끝이 interval 이내면 신선한 잡 — false', () => {
+    const endISO = new Date(now - 1 * H).toISOString();
+    expect(isStaleCatchupJob(endISO, 6, now)).toBe(false);
+  });
+
+  it('윈도우 끝이 interval보다 과거면 백로그 잡 — true', () => {
+    const endISO = new Date(now - 13 * H).toISOString();
+    expect(isStaleCatchupJob(endISO, 6, now)).toBe(true);
+  });
+
+  it('경계(정확히 interval)는 false — 정상 스케줄 잡을 백로그로 오판하지 않는다', () => {
+    const endISO = new Date(now - 6 * H).toISOString();
+    expect(isStaleCatchupJob(endISO, 6, now)).toBe(false);
+  });
+
+  it('잘못된 ISO 문자열은 보수적으로 false', () => {
+    expect(isStaleCatchupJob('not-a-date', 6, now)).toBe(false);
+  });
+});

--- a/apps/collector/src/queue/stale-job.ts
+++ b/apps/collector/src/queue/stale-job.ts
@@ -1,0 +1,18 @@
+/**
+ * 큐에 묵었다 늦게 실행된 "백로그(catch-up)" 잡 판정.
+ *
+ * 잡의 dateRange.endISO는 스케줄러/수동 트리거의 enqueue 시각(now)과 같다.
+ * 윈도우 끝이 한 interval 이상 과거라면 이 잡은 생성 후 큐에서 interval 이상
+ * 대기한 백로그다. 이런 잡의 완료가 subscription.nextRunAt을 now+interval로
+ * 밀면, 백로그가 소진될 때까지 스케줄러가 due를 보지 못해 신규(현재 윈도우)
+ * 잡 발급이 기아 상태에 빠진다 (2026-06-11 dcinside 운영 분석).
+ */
+export function isStaleCatchupJob(
+  windowEndISO: string,
+  intervalHours: number,
+  nowMs: number = Date.now(),
+): boolean {
+  const endMs = Date.parse(windowEndISO);
+  if (!Number.isFinite(endMs)) return false;
+  return nowMs - endMs > intervalHours * 3600 * 1000;
+}

--- a/apps/collector/src/server/trpc/runs.ts
+++ b/apps/collector/src/server/trpc/runs.ts
@@ -351,7 +351,9 @@ export const runsRouter = router({
         .update(collectionRuns)
         .set({
           status: 'failed',
-          durationMs: sql`EXTRACT(EPOCH FROM (NOW() - ${collectionRuns.time})) * 1000`,
+          // 수십 일 묵은 좀비 행은 EPOCH×1000이 integer 한계(~24.8일)를 넘어
+          // "integer out of range"로 강제 완료가 불가능했다 — LEAST로 캡.
+          durationMs: sql`LEAST(EXTRACT(EPOCH FROM (NOW() - ${collectionRuns.time})) * 1000, 2147483647)::int`,
           errorReason: 'force-completed from monitor (worker unresponsive)',
         })
         .where(

--- a/packages/collectors/src/adapters/base.ts
+++ b/packages/collectors/src/adapters/base.ts
@@ -70,7 +70,8 @@ export interface CollectionStats {
     | 'pageEmptyOrBlocked'
     | 'noMoreResults'
     | 'completed'
-    | 'quotaExhausted';
+    | 'quotaExhausted'
+    | 'windowUnreachable';
   /** 마지막으로 시도한 검색 페이지 번호 */
   lastPage: number;
   /** 일자별 수집 분포 (KST yyyy-mm-dd → count) */

--- a/packages/collectors/src/adapters/community-base-collector.ts
+++ b/packages/collectors/src/adapters/community-base-collector.ts
@@ -22,6 +22,36 @@ export abstract class CommunityBaseCollector extends BrowserCollector<CommunityP
   private static readonly MAX_CONSECUTIVE_EMPTY_PAGES = 5;
   // 빈/차단 페이지 지수 백오프 베이스 (10s → 20s → 40s → 80s → 160s).
   private static readonly EMPTY_PAGE_BACKOFF_BASE_MS = 10_000;
+  // 윈도우 도달 불가 외삽을 시작하기 위한 최소 표본 페이지 수.
+  private static readonly MIN_PAGES_FOR_UNREACHABLE_ESTIMATE = 10;
+  // 추정 오차 보호 마진 — 필요 페이지가 남은 예산의 N배를 넘을 때만 포기.
+  private static readonly UNREACHABLE_PAGES_MARGIN = 2;
+
+  /**
+   * 최신순 검색에서 페이지네이션 외삽으로 수집 윈도우 도달 가능성을 추정한다.
+   *
+   * 글 폭증 시(예: 선거 시즌 정치 키워드) maxSearchPages 예산이 몇 시간 분량밖에
+   * 거슬러 가지 못해 과거 윈도우 잡이 전 페이지를 헛돌고 0건으로 끝나는 문제의 가드.
+   * 표본(pagesSoFar)으로 측정한 페이지당 시간 진행 속도 대비, 남은 페이지 예산으로
+   * 윈도우 끝까지 도달할 수 없다고 추정되면 true.
+   */
+  static estimateWindowUnreachable(params: {
+    anchorNewestTs: number;
+    oldestSeenTs: number;
+    windowEndTs: number;
+    pagesSoFar: number;
+    maxPages: number;
+  }): boolean {
+    const { anchorNewestTs, oldestSeenTs, windowEndTs, pagesSoFar, maxPages } = params;
+    if (oldestSeenTs < windowEndTs) return false; // 이미 윈도우(또는 그 이전)에 도달
+    if (pagesSoFar < CommunityBaseCollector.MIN_PAGES_FOR_UNREACHABLE_ESTIMATE) return false;
+    const traversedMs = anchorNewestTs - oldestSeenTs;
+    if (traversedMs <= 0) return false; // 시간 진행 측정 불가 — 보수적으로 계속
+    const msPerPage = traversedMs / pagesSoFar;
+    const pagesNeeded = (oldestSeenTs - windowEndTs) / msPerPage;
+    const remaining = maxPages - pagesSoFar;
+    return pagesNeeded > remaining * CommunityBaseCollector.UNREACHABLE_PAGES_MARGIN;
+  }
 
   protected abstract readonly selectors: SiteSelectors;
   protected abstract readonly baseUrl: string;
@@ -262,6 +292,9 @@ export abstract class CommunityBaseCollector extends BrowserCollector<CommunityP
     let pageEmptyCount = 0;
     let endReason: CollectionStats['endReason'] = 'completed';
     let lastPageReached = 0;
+    // 윈도우 도달 가능성 외삽용 — 파싱 가능한 링크 시각의 페이지 진행 속도 추적
+    let anchorNewestTs: number | null = null;
+    let oldestSeenTs: number | null = null;
 
     const dayKey = (d: Date): number => kstDayStartMs(d);
 
@@ -299,6 +332,13 @@ export abstract class CommunityBaseCollector extends BrowserCollector<CommunityP
         continue;
       }
       consecutiveEmptyPages = 0;
+
+      for (const l of postLinks) {
+        const t = l.publishedAt?.getTime();
+        if (t === undefined || !Number.isFinite(t)) continue;
+        if (anchorNewestTs === null || t > anchorNewestTs) anchorNewestTs = t;
+        if (oldestSeenTs === null || t < oldestSeenTs) oldestSeenTs = t;
+      }
 
       const posts: CommunityPost[] = [];
 
@@ -414,6 +454,28 @@ export abstract class CommunityBaseCollector extends BrowserCollector<CommunityP
 
       const filtered = this.enforcePerDayCap(posts, dayKey, perDayLimit, enforced);
       if (filtered.length > 0) yield filtered;
+
+      // 과거 윈도우 도달 불가 조기 종료 — 아직 아무것도 수집하지 못한 catch-up 상태에서,
+      // 페이지당 시간 진행 속도를 외삽해 남은 페이지 예산으로 윈도우 끝까지 거슬러 갈 수
+      // 없으면 즉시 포기한다. (글 폭증 시 maxSearchPages 전체를 헛도는 낭비 방지)
+      if (
+        totalCollected === 0 &&
+        anchorNewestTs !== null &&
+        oldestSeenTs !== null &&
+        CommunityBaseCollector.estimateWindowUnreachable({
+          anchorNewestTs,
+          oldestSeenTs,
+          windowEndTs: daysDescMs[0] + 86400000,
+          pagesSoFar: pageNum,
+          maxPages: this.config.maxSearchPages,
+        })
+      ) {
+        endReason = 'windowUnreachable';
+        console.warn(
+          `${this.source} 윈도우 도달 불가 — page=${pageNum} 최고(古) ${new Date(oldestSeenTs).toISOString()} > 윈도우 끝 ${new Date(daysDescMs[0] + 86400000).toISOString()}, 남은 페이지 예산으로 도달 불가 추정 → 조기 종료`,
+        );
+        break;
+      }
 
       // 포화된 일자를 건너뜀 — 현재 dayIdx의 일자가 cap에 도달하면 앞으로 진행.
       // 이 과정에서 dayIdx >= daysDescMs.length가 되면 모든 일자가 완료 → 루프 탈출.

--- a/packages/collectors/tests/day-window-collector.test.ts
+++ b/packages/collectors/tests/day-window-collector.test.ts
@@ -219,4 +219,116 @@ describe('collectByDayWindowDescending', () => {
     });
     expect(posts).toHaveLength(2);
   });
+
+  it('과거 윈도우에 페이지 예산 내 도달이 불가능하면 windowUnreachable로 조기 종료한다', async () => {
+    // 글 폭증 재현: 링크가 20분 간격으로 쏟아져 페이지당 ~1시간씩만 과거로 전진.
+    // 앵커(06-10)에서 윈도우(05-30)까지 ~10.5일 — 100페이지 예산으로 도달 불가.
+    const anchor = kstDate('2026-06-10', '12:00').getTime();
+    const pages: FakeLink[][] = Array.from({ length: 100 }, (_, p) =>
+      Array.from({ length: 3 }, (_, i) => ({
+        url: `p${p}-${i}`,
+        title: `p${p}-${i}`,
+        publishedAt: new Date(anchor - (p * 3 + i) * 20 * 60 * 1000),
+      })),
+    );
+    const c = new FakeDayWindowCollector(pages);
+    const posts = await collectAll(c, {
+      keyword: 'test',
+      startDate: '2026-05-30T00:00:00+09:00',
+      endDate: '2026-05-30T00:00:00+09:00',
+      maxItems: 1000,
+      maxItemsPerDay: 100,
+      mode: 'incremental',
+    });
+    expect(posts).toHaveLength(0);
+    const stats = c.getLastRunStats();
+    expect(stats?.endReason).toBe('windowUnreachable');
+    // 100페이지를 다 돌지 않고 표본 구간(10페이지 부근)에서 멈춰야 한다
+    expect(stats?.lastPage).toBeLessThan(20);
+  });
+
+  it('과거 윈도우라도 페이지 예산 내 도달 가능하면 조기 종료 없이 수집한다', async () => {
+    // 페이지당 12시간씩 전진 — 3일 전 윈도우는 ~7페이지에 도달.
+    const anchor = kstDate('2026-06-10', '12:00').getTime();
+    const futurePages: FakeLink[][] = Array.from({ length: 6 }, (_, p) => [
+      { url: `f${p}`, title: `f${p}`, publishedAt: new Date(anchor - p * 12 * 3600 * 1000) },
+    ]);
+    const targetPage: FakeLink[] = [
+      { url: 'hit', title: 'hit', publishedAt: kstDate('2026-06-07', '10:00') },
+    ];
+    const c = new FakeDayWindowCollector([...futurePages, targetPage]);
+    const posts = await collectAll(c, {
+      keyword: 'test',
+      startDate: '2026-06-07T00:00:00+09:00',
+      endDate: '2026-06-07T00:00:00+09:00',
+      maxItems: 1000,
+      maxItemsPerDay: 100,
+      mode: 'incremental',
+    });
+    expect(posts.map((p) => p.url)).toEqual(['hit']);
+    expect(c.getLastRunStats()?.endReason).not.toBe('windowUnreachable');
+  });
+});
+
+describe('estimateWindowUnreachable', () => {
+  const H = 3600_000;
+  const base = {
+    anchorNewestTs: 1000 * H,
+    pagesSoFar: 20,
+    maxPages: 120,
+  };
+
+  it('이미 윈도우에 도달했으면 false', () => {
+    expect(
+      CommunityBaseCollector.estimateWindowUnreachable({
+        ...base,
+        oldestSeenTs: 900 * H,
+        windowEndTs: 950 * H,
+      }),
+    ).toBe(false);
+  });
+
+  it('표본 페이지 수가 부족하면 false', () => {
+    expect(
+      CommunityBaseCollector.estimateWindowUnreachable({
+        ...base,
+        pagesSoFar: 5,
+        oldestSeenTs: 995 * H,
+        windowEndTs: 100 * H,
+      }),
+    ).toBe(false);
+  });
+
+  it('남은 예산의 마진(2배) 이내로 도달 가능한 애매한 경우는 false', () => {
+    // 20페이지에 20시간 전진(1h/page), 남은 100페이지 × 마진 2 = 200h 여유, 갭 150h → 계속
+    expect(
+      CommunityBaseCollector.estimateWindowUnreachable({
+        ...base,
+        oldestSeenTs: 980 * H,
+        windowEndTs: 830 * H,
+      }),
+    ).toBe(false);
+  });
+
+  it('명백히 도달 불가하면 true', () => {
+    // 1h/page 속도로 갭 500h — 남은 100페이지 × 2 마진을 초과 → 포기
+    expect(
+      CommunityBaseCollector.estimateWindowUnreachable({
+        ...base,
+        oldestSeenTs: 980 * H,
+        windowEndTs: 480 * H,
+      }),
+    ).toBe(true);
+  });
+
+  it('시간 진행을 측정할 수 없으면(모든 링크 동일 시각) false', () => {
+    expect(
+      CommunityBaseCollector.estimateWindowUnreachable({
+        ...base,
+        anchorNewestTs: 980 * H,
+        oldestSeenTs: 980 * H,
+        windowEndTs: 100 * H,
+      }),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## 배경

큐 잼(#151) 해소 후에도 dcinside가 **6/3 이후 전 키워드 0건**이었습니다. 운영 분석(2026-06-11)으로 3중 결함을 확인했습니다.

## 근본 원인

1. **과거 윈도우 도달 불가 헛돌이** — 6월 지방선거로 정치 키워드 글이 폭증해, DC 최신순 검색의 120페이지 예산(≈3,000건 ≈ 수 시간 분량)으로는 과거 윈도우(예: 6/2 종료)에 도달할 수 없음. 그런데도 전 페이지를 크롤하며 잡당 ~40분을 낭비하고 `preFilterSkip`으로 전량 탈락 → 0건 (`reason=maxPagesReached preFilterSkip=2963` 운영 로그).
2. **nextRunAt 기아** — executor가 모든 잡 완료 시(8일 묵은 백로그 포함) `nextRunAt = now + interval`로 갱신 → 백로그가 도는 동안 스케줄러가 due를 못 봐 현재 윈도우 잡 발급이 무한 연기 (12시간 동안 2개만 발급된 것 확인).
3. **forceComplete 오버플로** — 24.8일+ 묵은 좀비 행은 `EXTRACT(EPOCH...)*1000`이 integer 한계 초과로 'integer out of range' → 모니터에서 강제 완료 불가 (4월 좀비 행 2건 잔존).

## 수정

- `community-base-collector`: 페이지당 시간 진행 속도 외삽으로 윈도우 도달 불가 판정 시 조기 종료 (`endReason='windowUnreachable'`, 표본 10페이지·마진 2배 — 보수적). 정적 순수 함수 `estimateWindowUnreachable`로 분리해 단위 테스트.
- `executor`: 윈도우 끝이 interval 이상 과거인 백로그 잡 완료는 `nextRunAt` 갱신 생략 (`isStaleCatchupJob` 신규 모듈).
- `runs.forceComplete`: duration을 `LEAST(..., 2147483647)::int`로 캡.

## 테스트

- [x] collectors 125/125 통과 (신규 7: windowUnreachable E2E 2 + estimateWindowUnreachable 단위 5)
- [x] collector 107/107 통과 (신규 4: isStaleCatchupJob 단위)
- [x] tsc 빌드/타입체크 통과, ESLint 에러 0
- [ ] 머지·배포 후: 4월 좀비 행(3d4d95b6) forceComplete 재시도로 오버플로 수정 검증

## 운영 조치 (코드 외, 완료)

도달 불가 백로그 57 run 취소·제거 + 5개 구독 dcinside 수동 트리거 (`triggerNow`) — 현재 윈도우 수집 재시동.

🤖 Generated with [Claude Code](https://claude.com/claude-code)