### PR TITLE
fix: stalled 한도 초과 terminal 실패 시 run 행 좀비화 해소

### DIFF
--- a/apps/collector/src/queue/startup-recovery.ts
+++ b/apps/collector/src/queue/startup-recovery.ts
@@ -13,6 +13,9 @@
 // 안전하게 orphan을 식별한다.
 
 import { Queue } from 'bullmq';
+import { and, lt, eq, sql } from 'drizzle-orm';
+import { getDb } from '../db';
+import { collectionRuns } from '../db/schema';
 import { getBullMQOptions } from './connection';
 import { isCancellationRequested } from './cancellation';
 import { COLLECTOR_SOURCES, type CollectionJobData } from './types';
@@ -95,4 +98,40 @@ export async function recoverOrphanedJobs(): Promise<void> {
   } else {
     console.log('[startup-recovery] orphaned job 없음');
   }
+}
+
+/**
+ * 어떤 finalize 경로도 못 탄 좀비 'running' 행 정리 — 워커 기동 시 1회 실행.
+ *
+ * worker.on('failed')의 finalize가 누락되는 경로(finalize 직전 크래시, DB 일시 장애,
+ * 잡이 실행 없이 큐에서 제거됨 등)에서 collection_runs가 running으로 영구 잔류한다.
+ * packages/core/src/analysis/stale-recovery.ts의 recoverStaleJobs와 동일 패턴.
+ *
+ * 임계 기본 90분: lockDuration 60분(worker-process.ts)을 초과하면 살아있는 잡일 수
+ * 없다 — 살아있다면 lock 갱신과 함께 청크 하트비트(last_progress_at)가 찍힌다.
+ *
+ * 정리된 행의 잡이 이후 재배달되더라도 ensureRunningRun이 새 running 행을
+ * INSERT하므로(재시도 이력 보존 설계) 데이터 손실은 없다.
+ */
+export async function recoverStaleRunningRuns(thresholdMinutes = 90): Promise<number> {
+  const cutoff = new Date(Date.now() - thresholdMinutes * 60_000);
+  const swept = await getDb()
+    .update(collectionRuns)
+    .set({
+      status: 'failed',
+      errorReason: `startup-recovery: stale running ${thresholdMinutes}분+ 무진행 (worker crash 추정)`,
+    })
+    .where(
+      and(
+        eq(collectionRuns.status, 'running'),
+        lt(sql`COALESCE(${collectionRuns.lastProgressAt}, ${collectionRuns.time})`, cutoff),
+      ),
+    )
+    .returning({ runId: collectionRuns.runId, source: collectionRuns.source });
+
+  if (swept.length > 0) {
+    const detail = swept.map((r) => `${r.runId.slice(0, 8)}/${r.source}`).join(', ');
+    console.warn(`[startup-recovery] stale running ${swept.length}건 failed 처리: ${detail}`);
+  }
+  return swept.length;
 }

--- a/apps/collector/src/queue/worker-process.ts
+++ b/apps/collector/src/queue/worker-process.ts
@@ -13,7 +13,7 @@ import {
   type CollectionJobResult,
 } from './types';
 import { executeCollectionJob } from './executor';
-import { recoverOrphanedJobs } from './startup-recovery';
+import { recoverOrphanedJobs, recoverStaleRunningRuns } from './startup-recovery';
 
 /**
  * 소스별 기동 전 환경 검증.
@@ -45,6 +45,56 @@ const CONCURRENCY: Record<CollectorSource, number> = {
   fmkorea: 1,
   clien: 1,
 };
+
+/** worker.on('failed')가 전달하는 job 중 finalize 판정에 필요한 최소 형태 */
+interface FailedJobInfo {
+  data: { runId: string };
+  attemptsMade: number;
+  finishedOn?: number;
+}
+
+/**
+ * executor의 catch를 거치지 않는 실패 경로(stalled 한도 초과 등)에서
+ * collection_runs가 status='running'으로 영구 orphan이 되는 것을 방지.
+ *
+ * terminal 판정은 attemptsMade 비교가 아니라 finishedOn 유무로 한다:
+ * BullMQ는 재시도 예정 실패(moveToDelayed/retryJob)에서는 finishedOn을 설정하지
+ * 않고, terminal 실패(attempts 소진·stalled 한도 초과(UnrecoverableError)·discard)
+ * 에서만 moveToFinished로 설정한 뒤 'failed'를 emit한다. stalled 한도 초과는
+ * attemptsMade < attempts 상태에서도 terminal이라(2026-06-11 run 2bbdb301 사건)
+ * attemptsMade 비교는 이 경우 finalize를 놓쳐 영구 running 좀비를 만든다.
+ */
+export async function finalizeTerminalFailedRun(
+  source: CollectorSource,
+  job: FailedJobInfo | undefined,
+  err: Error,
+): Promise<void> {
+  if (!job) return;
+  if (job.finishedOn == null) return; // 재시도 예정 — terminal 실패만 finalize
+
+  const runId = job.data.runId;
+  const reason = (err.message ?? 'unknown').slice(0, 500);
+  try {
+    await getDb()
+      .update(collectionRuns)
+      .set({
+        status: 'failed',
+        errorReason: `worker.failed: ${reason}`,
+      })
+      .where(
+        and(
+          eq(collectionRuns.runId, runId),
+          eq(collectionRuns.source, source),
+          eq(collectionRuns.status, 'running'),
+        ),
+      );
+  } catch (dbErr) {
+    console.error(
+      `[worker:${source}] failed-hook DB finalize 실패 runId=${runId}:`,
+      dbErr instanceof Error ? dbErr.message : dbErr,
+    );
+  }
+}
 
 function buildWorker(source: CollectorSource): Worker<CollectionJobData, CollectionJobResult> {
   const opts: WorkerOptions = {
@@ -84,36 +134,7 @@ function buildWorker(source: CollectorSource): Worker<CollectionJobData, Collect
     console.error(
       `[worker:${source}] failed runId=${job?.data.runId} attempt=${job?.attemptsMade}: ${err.message}`,
     );
-
-    // executor의 catch를 거치지 않는 실패 경로(stalled 초과 등)에서
-    // collection_runs가 status='running'으로 영구 orphan이 되는 것을 방지.
-    // 재시도 경쟁을 피하려고 '마지막 시도'일 때만 finalize.
-    if (!job) return;
-    const maxAttempts = job.opts.attempts ?? 1;
-    const isLastAttempt = job.attemptsMade >= maxAttempts;
-    if (!isLastAttempt) return;
-
-    const runId = job.data.runId;
-    const reason = (err.message ?? 'unknown').slice(0, 500);
-    void getDb()
-      .update(collectionRuns)
-      .set({
-        status: 'failed',
-        errorReason: `worker.failed: ${reason}`,
-      })
-      .where(
-        and(
-          eq(collectionRuns.runId, runId),
-          eq(collectionRuns.source, source),
-          eq(collectionRuns.status, 'running'),
-        ),
-      )
-      .catch((dbErr) => {
-        console.error(
-          `[worker:${source}] failed-hook DB finalize 실패 runId=${runId}:`,
-          dbErr instanceof Error ? dbErr.message : dbErr,
-        );
-      });
+    void finalizeTerminalFailedRun(source, job, err);
   });
 
   worker.on('error', (err) => {
@@ -154,6 +175,10 @@ async function main() {
   // Worker 시작 전 orphaned job 복구
   await recoverOrphanedJobs().catch((err) =>
     console.error('[startup-recovery] 복구 실패 (무시하고 계속):', err),
+  );
+  // 어떤 finalize 경로도 못 탄 좀비 running 행 정리 (terminal 실패 직전 크래시 등)
+  await recoverStaleRunningRuns().catch((err) =>
+    console.error('[startup-recovery] stale running 정리 실패 (무시하고 계속):', err),
   );
   console.warn('[worker-process] starting all source workers...');
   const workers = startAllWorkers();

--- a/apps/collector/src/queue/zombie-run-finalize.integration.test.ts
+++ b/apps/collector/src/queue/zombie-run-finalize.integration.test.ts
@@ -1,0 +1,146 @@
+// 좀비 running 행 finalize 통합 테스트
+// 2026-06-11 사건 회귀 방지: BullMQ stalled 한도 초과 실패는 attemptsMade < attempts
+// 상태에서도 terminal(UnrecoverableError, finishedOn 설정)인데, 기존 isLastAttempt
+// 가드가 finalize를 건너뛰어 collection_runs가 영구 running으로 방치됐다 (run 2bbdb301).
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { eq, and } from 'drizzle-orm';
+import { getDb } from '../db';
+import { collectionRuns, keywordSubscriptions } from '../db/schema';
+import { ensureRunningRun } from './executor';
+import { finalizeTerminalFailedRun } from './worker-process';
+import { recoverStaleRunningRuns } from './startup-recovery';
+
+const SOURCE = 'dcinside';
+
+describe('zombie running run finalize', () => {
+  let subId: number;
+  const runIds: string[] = [];
+
+  beforeEach(async () => {
+    const [sub] = await getDb()
+      .insert(keywordSubscriptions)
+      .values({
+        keyword: 'zombie-finalize-test',
+        sources: ['dcinside'],
+        intervalHours: 6,
+        limits: { maxPerRun: 10 },
+      })
+      .returning();
+    subId = sub.id;
+  });
+
+  afterEach(async () => {
+    for (const rid of runIds) {
+      await getDb().delete(collectionRuns).where(eq(collectionRuns.runId, rid));
+    }
+    runIds.length = 0;
+    await getDb().delete(keywordSubscriptions).where(eq(keywordSubscriptions.id, subId));
+  });
+
+  async function insertRunningRun(runId: string): Promise<void> {
+    runIds.push(runId);
+    await ensureRunningRun({
+      runId,
+      subscriptionId: subId,
+      source: SOURCE,
+      triggerType: 'manual' as const,
+    });
+  }
+
+  async function getRun(runId: string) {
+    const rows = await getDb()
+      .select()
+      .from(collectionRuns)
+      .where(and(eq(collectionRuns.runId, runId), eq(collectionRuns.source, SOURCE)));
+    expect(rows).toHaveLength(1);
+    return rows[0];
+  }
+
+  describe('finalizeTerminalFailedRun (worker.on failed 훅)', () => {
+    it('stalled 한도 초과(terminal, attemptsMade < attempts)면 running 행을 failed로 마킹한다', async () => {
+      const runId = randomUUID();
+      await insertRunningRun(runId);
+
+      // 사건 당시 잡 상태 재현: attempts 3 중 attemptsMade 2, finishedOn 설정(terminal)
+      await finalizeTerminalFailedRun(
+        SOURCE,
+        { data: { runId }, attemptsMade: 2, finishedOn: Date.now() },
+        new Error('job stalled more than allowable limit'),
+      );
+
+      const row = await getRun(runId);
+      expect(row.status).toBe('failed');
+      expect(row.errorReason).toContain('job stalled more than allowable limit');
+    });
+
+    it('재시도 예정 실패(finishedOn 미설정)면 행을 running으로 유지한다', async () => {
+      const runId = randomUUID();
+      await insertRunningRun(runId);
+
+      await finalizeTerminalFailedRun(
+        SOURCE,
+        { data: { runId }, attemptsMade: 1 },
+        new Error('Connection terminated due to connection timeout'),
+      );
+
+      const row = await getRun(runId);
+      expect(row.status).toBe('running');
+    });
+
+    it('job이 undefined여도 throw하지 않는다', async () => {
+      await expect(
+        finalizeTerminalFailedRun(SOURCE, undefined, new Error('boom')),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('recoverStaleRunningRuns (워커 기동 시 sweeper)', () => {
+    it('임계(90분) 이상 무진행 running 행을 failed로 정리하고 건수를 반환한다', async () => {
+      const runId = randomUUID();
+      await insertRunningRun(runId);
+      const staleTime = new Date(Date.now() - 91 * 60_000);
+      await getDb()
+        .update(collectionRuns)
+        .set({ time: staleTime, lastProgressAt: staleTime })
+        .where(eq(collectionRuns.runId, runId));
+
+      const swept = await recoverStaleRunningRuns(90);
+
+      expect(swept).toBeGreaterThanOrEqual(1);
+      const row = await getRun(runId);
+      expect(row.status).toBe('failed');
+      expect(row.errorReason).toContain('stale');
+    });
+
+    it('임계 미만의 running 행은 건드리지 않는다', async () => {
+      const runId = randomUUID();
+      await insertRunningRun(runId);
+      const recentTime = new Date(Date.now() - 30 * 60_000);
+      await getDb()
+        .update(collectionRuns)
+        .set({ time: recentTime, lastProgressAt: recentTime })
+        .where(eq(collectionRuns.runId, runId));
+
+      await recoverStaleRunningRuns(90);
+
+      const row = await getRun(runId);
+      expect(row.status).toBe('running');
+    });
+
+    it('이미 finalize된 행은 건드리지 않는다', async () => {
+      const runId = randomUUID();
+      await insertRunningRun(runId);
+      const staleTime = new Date(Date.now() - 120 * 60_000);
+      await getDb()
+        .update(collectionRuns)
+        .set({ time: staleTime, lastProgressAt: staleTime, status: 'completed' })
+        .where(eq(collectionRuns.runId, runId));
+
+      await recoverStaleRunningRuns(90);
+
+      const row = await getRun(runId);
+      expect(row.status).toBe('completed');
+    });
+  });
+});


### PR DESCRIPTION
## 증상

`@ais:sub/37/run/2bbdb301?keyword=한동훈&source=dcinside` — 한동훈 dcinside 수집이 모니터에 14시간 이상 '수집 중'으로 표시. 동일 패턴 좀비 `running` 행이 전 소스에 걸쳐 **14건** 확인 (2026-06-11 워커 9회 재부팅 날).

## 근본 원인 (운영 포렌식 + BullMQ 5.73 소스 검증)

1. 워커 프로세스가 6/11 하루 9회 사망 (pg Pool error 무리스너·OOM 의심 — 별도 이슈)
2. run 수명 중 워커 2회 사망 → BullMQ stall 카운트 2회 → `maxStalledCount=1` 초과 → **`job stalled more than allowable limit`으로 terminal 실패** (BullMQ는 `defa` → `UnrecoverableError` 경로로 attempts 잔여(2/3)와 무관하게 종결, processor 미호출)
3. `worker.on('failed')`의 `isLastAttempt` 가드(`attemptsMade >= attempts`)가 `2 < 3`이라 "재시도 예정"으로 오판 → DB finalize skip → **재시도는 영원히 오지 않고 행은 영구 `running`**
4. collector에는 stale running 행을 정리하는 sweeper가 없음 (분석 파이프라인의 `stale-recovery.ts`에는 존재)

## 수정

- **worker-process**: finalize 판정을 `attemptsMade` 비교 → `job.finishedOn` 유무로 교체. BullMQ는 terminal 실패(attempts 소진·stalled 한도·discard·maxStartedAttempts)에서만 `moveToFinished`로 `finishedOn`을 설정한 뒤 `'failed'`를 emit — 재시도 예정 실패(`moveToDelayed`/`retryJob`)에서는 설정하지 않음 (5.73.0 `job.js` `moveToFailed` 확인)
- **startup-recovery**: `recoverStaleRunningRuns(90)` 추가 — 기동 시 90분+ 무진행 `running` 행을 failed로 정리. 임계 90분 > lockDuration 60분이라 살아있는 잡 오판 불가. finalize 직전 크래시 등 잔여 누수 경로의 방어선 (core `stale-recovery.ts` 패턴 이식)

## 운영 조치 (완료)

- 좀비 행 14건을 `runs.forceComplete`(모니터 공식 경로)로 정리 — 잔여 0건 확인
- 14건 모두 BullMQ 측은 `failed`(stall-limit)·lock 없음 교차 검증 후 실행

## Test plan

- [x] 신규 통합 테스트 6건 GREEN (사건 재현: `attemptsMade=2 < attempts=3` + `finishedOn` 설정 → finalize)
- [x] collector 전체 테스트 151/151 (TEST_MODE=all)
- [x] tsc --noEmit 0 오류, ESLint 0 오류
- [x] 테스트 sweep의 공유 DB 부작용 없음 확인

## 잔여 과제 (별도)

- 워커 크래시 루프 자체: pg `Pool` error 리스너 부재 + `uncaughtException`/`unhandledRejection` 핸들러 부재 + heap cap 없음(현재 RSS 5.7GB/8GiB) — 후속 이슈로 등록

🤖 Generated with [Claude Code](https://claude.com/claude-code)