### PR TITLE
fix: 워커 크래시 루프 해소 — pg Pool error 리스너·프로세스 가드·heap cap

### DIFF
--- a/apps/collector/src/db/index.ts
+++ b/apps/collector/src/db/index.ts
@@ -17,6 +17,12 @@ function getPool() {
       // connection timeout"이 만성적으로 발생한다. 추론 블록 길이를 흡수하도록 30초로 완화.
       connectionTimeoutMillis: 30000,
     });
+    // idle client 소켓 에러(connect ETIMEDOUT 등)는 리스너가 없으면 unhandled
+    // 'error' 이벤트로 승격되어 프로세스가 즉사한다 (이슈 #154 유형 A).
+    // 풀이 해당 클라이언트를 폐기하고 다음 acquire에서 재연결하므로 로그만 남긴다.
+    _pool.on('error', (err) => {
+      console.error('[db] pg pool idle client error (풀이 재연결 처리):', err.message);
+    });
   }
   return _pool;
 }

--- a/apps/collector/src/db/pool-error-resilience.test.ts
+++ b/apps/collector/src/db/pool-error-resilience.test.ts
@@ -1,0 +1,21 @@
+// pg Pool idle client error 내성 테스트 (이슈 #154 유형 A 회귀 방지)
+// 2026-06-11 사건: idle client의 connect ETIMEDOUT이 Pool의 unhandled 'error'
+// 이벤트로 승격되어 워커 프로세스가 즉사 (하루 9회 재부팅). pool.on('error')
+// 리스너가 있으면 EventEmitter가 throw하지 않고 로그만 남긴다.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getDb } from './index';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('collector pg Pool error 내성', () => {
+  it("idle client 'error' 이벤트가 throw로 승격되지 않는다 (리스너 존재)", () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const pool = getDb().$client;
+
+    // 리스너가 없으면 EventEmitter 규약상 emit('error')가 동기 throw → 프로세스 즉사 재현
+    expect(() => pool.emit('error', new Error('connect ETIMEDOUT'))).not.toThrow();
+    expect(errSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/collector/src/queue/process-guards.test.ts
+++ b/apps/collector/src/queue/process-guards.test.ts
@@ -1,0 +1,66 @@
+// 프로세스 레벨 크래시 가드 테스트 (이슈 #154)
+// uncaughtException/unhandledRejection 핸들러가 없으면 워커가 무로그로 즉사해
+// 사망 원인 추적이 불가능하다 (2026-06-11 유형 B). 가드는 원인을 로그한 뒤
+// exit(1)로 종료해 docker restart가 깨끗하게 재기동하도록 한다.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { registerProcessGuards } from './worker-process';
+
+// 테스트가 추가한 리스너만 정리하기 위해 기존 리스너를 기억
+let priorUncaught: NodeJS.UncaughtExceptionListener[];
+let priorRejection: NodeJS.UnhandledRejectionListener[];
+
+beforeEach(() => {
+  priorUncaught = process.listeners('uncaughtException');
+  priorRejection = process.listeners('unhandledRejection');
+});
+
+afterEach(() => {
+  for (const l of process.listeners('uncaughtException')) {
+    if (!priorUncaught.includes(l)) process.removeListener('uncaughtException', l);
+  }
+  for (const l of process.listeners('unhandledRejection')) {
+    if (!priorRejection.includes(l)) process.removeListener('unhandledRejection', l);
+  }
+  vi.restoreAllMocks();
+});
+
+describe('registerProcessGuards', () => {
+  it('uncaughtException/unhandledRejection 핸들러를 등록한다', () => {
+    registerProcessGuards();
+
+    expect(process.listenerCount('uncaughtException')).toBe(priorUncaught.length + 1);
+    expect(process.listenerCount('unhandledRejection')).toBe(priorRejection.length + 1);
+  });
+
+  it('uncaughtException 핸들러가 원인을 로그하고 exit(1)한다', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    registerProcessGuards();
+    const handler = process.listeners('uncaughtException').at(-1);
+    if (!handler) throw new Error('uncaughtException 핸들러 미등록');
+    handler(new Error('boom'), 'uncaughtException');
+
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('uncaughtException'),
+      expect.any(Error),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('unhandledRejection 핸들러가 원인을 로그하고 exit(1)한다', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    registerProcessGuards();
+    const handler = process.listeners('unhandledRejection').at(-1);
+    if (!handler) throw new Error('unhandledRejection 핸들러 미등록');
+    handler(new Error('rejected'), Promise.resolve());
+
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('unhandledRejection'),
+      expect.any(Error),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/collector/src/queue/worker-process.ts
+++ b/apps/collector/src/queue/worker-process.ts
@@ -96,6 +96,25 @@ export async function finalizeTerminalFailedRun(
   }
 }
 
+/**
+ * 프로세스 레벨 크래시 가드 (이슈 #154 유형 B 진단).
+ *
+ * 핸들러가 없으면 uncaughtException/unhandledRejection이 무로그 즉사로 이어져
+ * 사망 원인 추적이 불가능하다 (2026-06-11 하루 9회 재부팅 중 다수가 원인 미상).
+ * 프로세스 상태는 이미 불확정이므로 복구를 시도하지 않고, 원인을 로그한 뒤
+ * exit(1)로 종료해 docker restart(unless-stopped)가 깨끗하게 재기동하게 한다.
+ */
+export function registerProcessGuards(): void {
+  process.on('uncaughtException', (err) => {
+    console.error('[worker-process] uncaughtException — 종료 후 재기동:', err);
+    process.exit(1);
+  });
+  process.on('unhandledRejection', (reason) => {
+    console.error('[worker-process] unhandledRejection — 종료 후 재기동:', reason);
+    process.exit(1);
+  });
+}
+
 function buildWorker(source: CollectorSource): Worker<CollectionJobData, CollectionJobResult> {
   const opts: WorkerOptions = {
     ...getBullMQOptions(),
@@ -170,6 +189,7 @@ export async function shutdownWorkers(
  * docker-compose의 collector-worker 서비스가 사용.
  */
 async function main() {
+  registerProcessGuards();
   console.warn('[worker-process] verifying hypertable constraints...');
   await assertHypertableConstraints();
   // Worker 시작 전 orphaned job 복구

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -152,6 +152,10 @@ services:
       - ../.env.production
     environment:
       NODE_ENV: production
+      # V8 heap cap — mem_limit 8g 중 네이티브 몫(onnxruntime·Playwright chromium 자식)을
+      # 남긴다. cap이 없으면 V8이 cgroup 한도를 모른 채 heap을 키우다 무로그 OOM kill로
+      # 즉사한다 (이슈 #154 유형 B, RSS 5.7GB 관측).
+      NODE_OPTIONS: --max-old-space-size=5120
       DATABASE_URL: ${COLLECTOR_DATABASE_URL:-postgres://postgres:krdn_fx_2026@host.docker.internal:5435/ais_collection}
       REDIS_URL: ${COLLECTOR_REDIS_URL:-redis://redis:6379}
       BULL_PREFIX: collector

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -7,14 +7,27 @@ import * as schema from './schema';
 let _pool: pg.Pool | null = null;
 let _db: ReturnType<typeof drizzle<typeof schema>> | null = null;
 
+// idle client 소켓 에러(connect ETIMEDOUT 등)는 리스너가 없으면 unhandled
+// 'error' 이벤트로 승격되어 프로세스가 즉사한다 (이슈 #154 동일 결함).
+// 풀이 해당 클라이언트를 폐기하고 다음 acquire에서 재연결하므로 로그만 남긴다.
+function attachPoolErrorLogger(pool: pg.Pool, label: string): pg.Pool {
+  pool.on('error', (err) => {
+    console.error(`[db:${label}] pg pool idle client error (풀이 재연결 처리):`, err.message);
+  });
+  return pool;
+}
+
 function getPool() {
   if (!_pool) {
-    _pool = new pg.Pool({
-      connectionString: process.env.DATABASE_URL,
-      max: 20,
-      idleTimeoutMillis: 30000,
-      connectionTimeoutMillis: 5000,
-    });
+    _pool = attachPoolErrorLogger(
+      new pg.Pool({
+        connectionString: process.env.DATABASE_URL,
+        max: 20,
+        idleTimeoutMillis: 30000,
+        connectionTimeoutMillis: 5000,
+      }),
+      'lazy',
+    );
   }
   return _pool;
 }
@@ -30,9 +43,12 @@ export function getDb() {
 // DrizzleAdapter 등 instanceof 검사가 필요한 곳에서 사용
 // 주의: Worker 프로세스에서는 이 export 대신 getDb()를 사용할 것
 export const db = drizzle(
-  new pg.Pool({
-    connectionString: process.env.DATABASE_URL,
-  }),
+  attachPoolErrorLogger(
+    new pg.Pool({
+      connectionString: process.env.DATABASE_URL,
+    }),
+    'eager',
+  ),
   { schema },
 );
 export type Database = typeof db;

--- a/packages/core/src/db/pool-error-resilience.test.ts
+++ b/packages/core/src/db/pool-error-resilience.test.ts
@@ -1,0 +1,28 @@
+// pg Pool idle client error 내성 테스트 (이슈 #154 동일 결함 — core 측)
+// collector 워커와 동일하게 core의 lazy Pool(getDb)·eager Pool(db) 모두
+// 'error' 리스너가 없으면 idle client 소켓 에러가 프로세스를 즉사시킨다.
+// (analysis-worker는 getDb, Next.js는 eager db 사용)
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getDb, db } from './index';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('core pg Pool error 내성', () => {
+  it("lazy Pool(getDb): idle client 'error' 이벤트가 throw로 승격되지 않는다", () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const pool = getDb().$client;
+
+    expect(() => pool.emit('error', new Error('connect ETIMEDOUT'))).not.toThrow();
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("eager Pool(db): idle client 'error' 이벤트가 throw로 승격되지 않는다", () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const pool = db.$client;
+
+    expect(() => pool.emit('error', new Error('connect ETIMEDOUT'))).not.toThrow();
+    expect(errSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 배경

2026-06-11 하루에만 collector 워커가 9회 재부팅 (#154). PR #151~#153은 증상(유령 실행·좀비 행)을 차단했고, 이 PR이 크래시 원인 자체를 수정한다.

## 변경 내용

| 사망 유형 | 원인 | 수정 |
|---|---|---|
| A. 네트워크 블립 즉사 | `pg.Pool`에 `error` 리스너 없음 → idle client의 `connect ETIMEDOUT`이 unhandled 'error' 이벤트로 승격 | `apps/collector/src/db/index.ts` + `packages/core/src/db/index.ts`(lazy·eager 양쪽) — `pool.on('error')` 로그 후 풀 재연결에 위임 |
| A 보조 | `uncaughtException`/`unhandledRejection` 핸들러 부재 → 무로그 즉사 | `worker-process.ts` — `registerProcessGuards()`: 원인 로그 후 `exit(1)` (docker restart가 깨끗하게 재기동) |
| B. 무로그 OOM kill | V8이 cgroup 한도(8g)를 모른 채 heap 팽창 (RSS 5.7GB 관측) | compose `NODE_OPTIONS=--max-old-space-size=5120` — 네이티브(onnxruntime·chromium) 몫 ~3g 확보 |

## 테스트 (TDD)

- [x] RED: `pool.emit('error', connect ETIMEDOUT)`가 throw로 승격됨을 재현 (collector 1건 + core lazy/eager 2건)
- [x] RED: `registerProcessGuards` 부재 확인 (3건)
- [x] GREEN: 6/6 통과 — collector 111/111, core 502/502(6 skip) 전체 회귀 통과
- [x] tsc `--noEmit` collector·core 통과, ESLint 변경 파일 0 이슈
- [ ] 배포 후: `docker logs ais-collector-worker`에서 재부팅 빈도 감소 확인 (`Tini is not running` 배너 카운트)

## 잔여 (이슈 #154 권장 조치 4·5)

- 메모리 성장 원인 프로파일링(임베딩 배치 스트리밍화)·healthcheck 실효화는 별도 후속

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)