### PR TITLE
fix: 구독 RAG 경로 데이터 손실 — under-deliver 시 fullset 병합 복구

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,58 @@
+# CONTEXT — AI SignalCraft 도메인·아키텍처 어휘
+
+아키텍처 리뷰(`/improve-codebase-architecture`)와 디버깅에서 확정된 도메인 언어와
+**load-bearing invariant**(손대면 안 되는 의도된 설계)를 기록한다. 새 리뷰가 같은 지점을
+"낮게 매달린 열매"로 다시 제안하지 않도록 하는 것이 목적이다.
+
+## 도메인 어휘
+
+- **AnalysisInput** — DB/collector에서 로드한 분석 입력(articles/videos/comments/dateRange/domain).
+  분석 모듈 전체가 읽는 핵심 도메인 모델. 삭제 테스트 통과(개념 자체는 제 몫을 함).
+- **구성 경로(intake) 이중성** — `AnalysisInput`을 만드는 두 경로:
+  - **키워드 경로** `loadAnalysisInput` — 분석 DB N:M 조인 직접 조회.
+  - **구독 경로** `loadAnalysisInputViaCollector` → `loadAnalysisInputFromCollector` — collector RPC(RAG).
+  - 선택은 `pipeline-orchestrator.ts`의 `isCollectorPath`(`USE_COLLECTOR_LOADER`/job options).
+- **ragSample vs fullset** — collector RPC `fetchAnalysisPayload` 반환의 두 데이터:
+  - `ragSample`: 의미검색으로 추린 관련 상위 항목. **유사도 컷오프 없음**(거리순 topK).
+  - `fullset`: 잡 윈도우 전체 풀(최대 50,000). linkage 복원·폴백용.
+  - 둘은 "둘 중 하나"가 아니라 목적이 다른 데이터. 게이트는 `selectAnalysisRows`가 담당.
+- **un-inflated 타겟 vs articleVideoTopK** — `articleTopK+clusterRepresentatives`/`commentTopK`가
+  다운스트림 컷 타겟(진짜 필요량). `articleVideoTopK`는 그것을 ×3·1500cap한 **over-fetch 요청값**.
+  RAG가 충분히 줬는지 판정할 땐 반드시 **un-inflated 타겟**과 비교한다(over-fetch 값 아님).
+
+## Load-bearing invariants (do NOT "refactor away")
+
+리뷰가 shallow/DRY로 오인하기 쉬우나 의도된 설계다.
+
+### 1. BullMQ prefix 분기 = 서비스 격리 (통일 금지)
+
+- `packages/core/src/queue/connection.ts` → `bull`(운영)/`ais-dev`(개발).
+- `apps/collector/src/queue/connection.ts` → `collector`/`collector-dev`.
+- core와 collector는 **같은 Redis를 공유하되 prefix로 큐를 분리**한다. 통일하면 두 서비스가
+  한 네임스페이스로 병합 → 유령 실행 릴레이·워커 크래시 루프(PR #151/#155)의 큐 오염 재현.
+- `getBullMQOptions()` 수동 spread(16곳)는 caller discipline이지만, prefix 분기 자체는 결함이 아님.
+
+### 2. control.ts 큐 스코프: 전역 vs 잡별 (제네릭 가드로 묶지 말 것)
+
+- `pausePipeline`/`resumePipeline`은 **전역** `getQueue('analysis').pause()/.resume()` (전체 잡 영향).
+- `cancelPipeline`은 **잡별** `removeWaitingBullMQJobs(jobId)`.
+- `setCostLimit`/`setSkippedModules`는 **의도적으로 가드 없음**(running/paused 잡도 변경 허용).
+- 이 호출별 부작용 변이를 `guardedTransition` 슬롯으로 숨기면 cross-job 파손(#153,
+  `run_cancellations` cooperative cancel 단일 진실)을 유발한다.
+
+### 3. kit는 domain-agnostic — wrapper가 정답 (kit 인터페이스 확장 금지)
+
+- `runner.ts`의 `boundModule`이 `input.domain`/priorResults/JSON_REMINDER를 closure로 바인딩.
+- kit(`@krdn/llm-gateway`)은 `buildSystemPrompt()`를 인자 없이 호출(by design). 단일 호출처라
+  "잊을" 수 없고, 고토큰 Stage 1은 map-reduce로 kit을 우회한다.
+- domain을 kit 인터페이스로 밀면 다른 소비처(아키텍처 워크플로 보고 기준 tickerlens·
+  ai-afterschool-fsd — 미검증)로 횡단 확장 → cross-repo blast radius. 현재 wrapper가
+  adapter 경계의 정확한 seam.
+
+### 4. collector RAG fallback 게이트 의미론 (`selectAnalysisRows`)
+
+- collector RAG는 유사도 컷오프가 없어 ragSample이 거의 0건이 안 된다. 따라서 "0건이면 폴백"은
+  무력화되고, 임베딩 희소(NULL 29~72%)로 RAG가 under-deliver하면 데이터 손실이 났었다(수정됨).
+- 현재 판정: ragRows가 **un-inflated 타겟 이상**이면 신뢰(관련도 순위 보존), 미달이고 풀이 더 크면
+  `dedup(ragRows ++ fullset)` 병합으로 **커버리지 복구**(이후 시계열 컷이 재샘플하므로 순위가
+  아닌 범위 복구). 무조건 병합 금지(RAG 성공 시 관련도 신호 파괴).

--- a/packages/core/src/analysis/data-loader.ts
+++ b/packages/core/src/analysis/data-loader.ts
@@ -266,19 +266,27 @@ export async function loadAnalysisInputFromCollector(
   });
 
   // ragSample → AnalysisInput
-  // itemType별로 독립 폴백 — ragSample에 해당 itemType이 없으면 fullset 전체를 사용.
-  // rag-light처럼 articleTopK=0인 프리셋은 ragSample에 기사가 없으므로 fullset에서 전체 유지.
-  // rag-standard처럼 RAG가 유사도 미달로 0건을 반환했을 때도 fullset으로 자동 복구.
+  // RAG가 "요청한 topK 근처"를 반환했으면 의미 선별이 정상 동작한 것 → ragSample 신뢰.
+  // 임베딩 희소(NULL률 높음) 등으로 요청량보다 크게 미달하면 under-deliver → fullset 병합 복구.
+  // 비교 기준은 ×3 인플레된 articleVideoTopK가 아니라 다운스트림 컷 타겟(un-inflated)이다.
+  // (rag-light처럼 articleTopK=0인 프리셋은 타겟 0이므로 항상 ragSample을 그대로 통과.)
   const ragArticles = resp.ragSample.filter((i) => i.itemType === 'article');
   const ragVideos = resp.ragSample.filter((i) => i.itemType === 'video');
   const ragComments = resp.ragSample.filter((i) => i.itemType === 'comment');
+  const fullArticles = resp.fullset.filter((i) => i.itemType === 'article');
+  const fullVideos = resp.fullset.filter((i) => i.itemType === 'video');
+  const fullComments = resp.fullset.filter((i) => i.itemType === 'comment');
 
-  const articleRows =
-    ragArticles.length > 0 ? ragArticles : resp.fullset.filter((i) => i.itemType === 'article');
-  const videoRows =
-    ragVideos.length > 0 ? ragVideos : resp.fullset.filter((i) => i.itemType === 'video');
-  const commentRows =
-    ragComments.length > 0 ? ragComments : resp.fullset.filter((i) => i.itemType === 'comment');
+  // article+video는 collector가 단일 topK로 함께 요청하므로 결합해 판정한다.
+  // 타겟(articleVideoTarget/commentTarget)은 위 collector 요청 계산과 동일한 un-inflated 값.
+  const selectedArticleVideo = selectAnalysisRows(
+    [...ragArticles, ...ragVideos],
+    [...fullArticles, ...fullVideos],
+    articleVideoTarget,
+  );
+  const articleRows = selectedArticleVideo.filter((i) => i.itemType === 'article');
+  const videoRows = selectedArticleVideo.filter((i) => i.itemType === 'video');
+  const commentRows = selectAnalysisRows(ragComments, fullComments, commentTarget);
 
   const articlesOut = articleRows
     .filter((a) => a.title)
@@ -340,6 +348,51 @@ export async function loadAnalysisInputFromCollector(
     fullset,
     collectionMeta: resp.collectionMeta,
   };
+}
+
+/**
+ * collector RAG 결과(ragRows)와 전체 풀(fullsetRows)을 합쳐 분석 입력 행을 선택한다.
+ *
+ * collector 측 RAG에는 유사도 컷오프가 없어 ragSample은 거의 항상 0건이 아니다.
+ * 따라서 "0건이면 폴백" 게이트는 무력화되고, 임베딩 희소(NULL률 높음)로 RAG가
+ * 요청량보다 크게 미달해도 그 소수만 쓰고 fullset 전체를 버리는 데이터 손실이 발생했다.
+ *
+ * 판정 기준은 "RAG가 요청한 targetK 근처를 반환했는가":
+ *   - targetK <= 0               → 이 itemType은 RAG 미요청 → fullset 전체 사용
+ *   - ragRows >= targetK         → RAG가 충분히 선별 → ragRows 그대로 (관련도 순위 보존)
+ *   - ragRows < targetK & 풀 더 큼 → under-deliver → dedup(ragRows ++ fullsetRows)로 복구
+ *   - 그 외(풀도 작음)            → ragRows 그대로 (폴백 무의미)
+ *
+ * 무조건 병합하지 않는 이유: RAG가 충분히 반환했을 때 병합 후 다운스트림 시계열 컷을 하면
+ * 관련 선별 결과가 전체의 시간 샘플로 대체되어 RAG가 동작한 경우의 관련도 신호를 파괴한다.
+ * 병합 결과는 runTokenOptimization의 stratifiedSample이 presetTopK로 캡하므로 토큰 안전.
+ *
+ * @param targetK collector가 요청한 un-inflated 다운스트림 컷 타겟 (×3 인플레값 아님).
+ *               0이면 해당 itemType을 RAG로 요청하지 않은 것 → fullset 전체 사용.
+ */
+export function selectAnalysisRows<T extends Record<string, unknown>>(
+  ragRows: T[],
+  fullsetRows: T[],
+  targetK: number,
+): T[] {
+  // 이 itemType은 RAG 미요청 — ragSample에 없으므로 fullset 전체로 폴백 (rag-light의 기사 등).
+  if (targetK <= 0) return ragRows.length > 0 ? ragRows : fullsetRows;
+  const delivered = ragRows.length >= targetK;
+  if (delivered || fullsetRows.length <= ragRows.length) return ragRows;
+
+  // under-deliver — ragRows에 fullset을 합쳐 커버리지를 복구한다.
+  // (RAG가 미달했으므로 관련도 순위는 이미 신뢰할 수 없고, 이후 시계열 컷이 시간 기준으로
+  //  재샘플하므로 순위 보존이 아니라 '범위 복구'가 목적이다.)
+  // collector가 쓰는 동일 키(source::sourceId::itemType)로 중복 제거.
+  const seen = new Set<string>();
+  const merged: T[] = [];
+  for (const r of [...ragRows, ...fullsetRows]) {
+    const key = `${String(r.source)}::${String(r.sourceId)}::${String(r.itemType)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(r);
+  }
+  return merged;
 }
 
 function toDate(d: string | Date | null): Date {

--- a/packages/core/tests/p4-collector-rag.test.ts
+++ b/packages/core/tests/p4-collector-rag.test.ts
@@ -67,9 +67,11 @@ describe('fetchAnalysisPayload 단일 RPC 기반 data-loader', () => {
     dbMock.mockReset();
   });
 
-  it('ragConfig 있을 때(rag-standard): ragSample에서 input 구성, fullset/collectionMeta도 반환', async () => {
+  it('rag-standard에서 RAG under-deliver(요청 1500 대비 3건)면 fullset 병합으로 복구', async () => {
     dbMock.mockResolvedValue([baseJob]);
 
+    // RAG가 요청 topK(타겟 600)보다 크게 미달(article 3건) — 임베딩 희소 신호.
+    // sourceId가 fullset과 겹치므로 dedup 후 fullset 커버리지(10건)로 복구돼야 한다.
     const ragSample = [
       ...Array.from({ length: 3 }, (_, i) => makeRow('article', i)),
       ...Array.from({ length: 2 }, (_, i) => makeRow('comment', i)),
@@ -103,9 +105,11 @@ describe('fetchAnalysisPayload 단일 RPC 기반 data-loader', () => {
     expect(call.ragOptions.articleVideoTopK).toBe(1500);
     expect(call.ragOptions.commentTopK).toBe(1350);
 
-    // input은 ragSample(3개 article, 2개 comment)에서 구성
-    expect(result.input.articles.length).toBe(3);
-    expect(result.input.comments.length).toBe(2);
+    // under-deliver → ragSample(3) + fullset(10) 병합·dedup = 기사 10건으로 복구
+    // (예전 버그: ragSample 3건만 쓰고 fullset 7건을 버렸음)
+    expect(result.input.articles.length).toBe(10);
+    // 댓글도 target(450) 미달이므로 동일하게 병합·dedup = 5건
+    expect(result.input.comments.length).toBe(5);
 
     // fullset은 Drizzle insert 형태로 변환
     expect(result.fullset.articles.length).toBe(10);
@@ -119,7 +123,7 @@ describe('fetchAnalysisPayload 단일 RPC 기반 data-loader', () => {
     expect(result.collectionMeta.sources).toContain('naver-news');
   });
 
-  it('rag-light 프리셋: 기사는 fullset 전체 유지, 댓글만 RAG 필터', async () => {
+  it('rag-light 프리셋: 기사는 RAG 미요청이라 fullset 유지, 댓글 under-deliver면 병합 복구', async () => {
     dbMock.mockResolvedValue([
       {
         ...baseJob,
@@ -156,10 +160,10 @@ describe('fetchAnalysisPayload 단일 RPC 기반 data-loader', () => {
     expect(call.ragOptions).not.toHaveProperty('articleVideoTopK');
     expect(call.ragOptions.commentTopK).toBe(750);
 
-    // 기사는 ragSample에 없으므로 fullset(5건)에서 폴백
+    // 기사는 RAG 미요청(target 0)이고 ragSample에 없으므로 fullset(5건)에서 폴백
     expect(result.input.articles.length).toBe(5);
-    // 댓글은 ragSample(5건)에서
-    expect(result.input.comments.length).toBe(5);
+    // 댓글 5건은 target(250) 미달 → under-deliver → fullset(10건) 병합·dedup으로 복구
+    expect(result.input.comments.length).toBe(10);
 
     // fullset 변환도 정상
     expect(result.fullset.articles.length).toBe(5);

--- a/packages/core/tests/select-analysis-rows.test.ts
+++ b/packages/core/tests/select-analysis-rows.test.ts
@@ -1,0 +1,63 @@
+// selectAnalysisRows — collector RAG 결과/전체 풀 병합 게이트 단위 검증.
+// DB·collector mock 없이 순수 함수만 직접 호출한다.
+import { describe, it, expect } from 'vitest';
+import { selectAnalysisRows } from '../src/analysis/data-loader';
+
+type Row = { source: string; sourceId: string; itemType: 'article' | 'video' | 'comment' };
+
+function rows(itemType: Row['itemType'], n: number, prefix = 'rag'): Row[] {
+  return Array.from({ length: n }, (_, i) => ({
+    source: 'naver-news',
+    sourceId: `${prefix}-${itemType}-${i}`,
+    itemType,
+  }));
+}
+
+describe('selectAnalysisRows', () => {
+  it('RAG가 targetK 이상 반환하면 ragRows를 그대로 통과 (관련도 선별 보존)', () => {
+    const rag = rows('article', 600);
+    const full = rows('article', 5000, 'full');
+    const out = selectAnalysisRows(rag, full, 600);
+    expect(out).toHaveLength(600);
+    expect(out).toBe(rag); // 동일 참조 — fullset 미접촉
+  });
+
+  it('RAG가 targetK 미달이고 풀이 더 크면 병합·dedup으로 복구', () => {
+    // sourceId가 겹치지 않는 독립 행 → 병합 시 모두 유지
+    const rag = rows('article', 3, 'rag');
+    const full = rows('article', 10, 'full');
+    const out = selectAnalysisRows(rag, full, 600);
+    expect(out).toHaveLength(13); // 3 + 10, 중복 없음
+  });
+
+  it('병합 시 collector 키(source::sourceId::itemType)로 중복 제거', () => {
+    // ragRows의 0,1,2가 fullset의 0,1,2와 동일 sourceId → dedup
+    const rag = rows('article', 3, 'x');
+    const full = rows('article', 10, 'x'); // 같은 prefix → sourceId 0~2 겹침
+    const out = selectAnalysisRows(rag, full, 600);
+    expect(out).toHaveLength(10); // 3 + 7 신규
+  });
+
+  it('under-deliver여도 풀이 ragRows보다 크지 않으면 폴백 무의미 → ragRows 유지', () => {
+    const rag = rows('article', 3, 'rag');
+    const full = rows('article', 2, 'full');
+    const out = selectAnalysisRows(rag, full, 600);
+    expect(out).toBe(rag);
+  });
+
+  it('targetK<=0 (RAG 미요청 itemType): ragRows 있으면 그대로, 없으면 fullset 전체', () => {
+    // rag-light의 기사처럼 ragSample에 없는 경우 → fullset 폴백
+    const full = rows('article', 5, 'full');
+    expect(selectAnalysisRows([] as Row[], full, 0)).toBe(full);
+    // ragRows가 있으면(예외적) 그대로
+    const rag = rows('article', 4, 'rag');
+    expect(selectAnalysisRows(rag, full, 0)).toBe(rag);
+  });
+
+  it('article+video 결합 판정: 합산이 targetK 이상이면 통과', () => {
+    const rag = [...rows('article', 400, 'rag'), ...rows('video', 250, 'rag')];
+    const full = [...rows('article', 5000, 'full'), ...rows('video', 1000, 'full')];
+    const out = selectAnalysisRows(rag, full, 600); // 650 >= 600 → 통과
+    expect(out).toBe(rag);
+  });
+});


### PR DESCRIPTION
## 문제

구독 분석 경로(`USE_COLLECTOR_LOADER`)에서 **7일치 분석이 사실상 최근 ~130개로 붕괴**하는 데이터 손실이 있었습니다.

근본 원인 (데이터 흐름 추적으로 확정):
- collector RAG(`fetchAnalysisPayload`)는 **유사도 컷오프 없이** 거리순 topK만 뽑아 `ragSample`이 거의 0건이 안 됩니다.
- 그래서 `data-loader.ts`의 게이트 `ragArticles.length > 0`이 의도한 "RAG 0건이면 fullset 폴백"이 **무력화**됐습니다.
- 임베딩 희소(NULL 29~72%)로 RAG가 요청 topK보다 크게 미달해도, 그 빈약한 소수만 쓰고 `fullset`(최대 50,000) 전체를 버렸습니다.

## 수정

게이트 로직을 순수 함수 `selectAnalysisRows(ragRows, fullsetRows, targetK)`로 추출하고, 판정 기준을 "RAG가 요청한 만큼 줬는가"로 교체했습니다.

- 비교 기준은 **un-inflated 타겟**(`articleTopK + clusterRepresentatives` / `commentTopK`) — ×3·1500cap된 over-fetch 요청값(`articleVideoTopK`)이 아님
- `ragRows >= targetK` → ragRows 그대로 (관련도 순위 보존)
- `ragRows < targetK` & 풀이 더 큼 → `dedup(ragRows ++ fullset)` **커버리지 복구** (collector 키 `source::sourceId::itemType`)
- `targetK <= 0` (RAG 미요청 itemType, 예: rag-light 기사) → fullset 폴백
- article+video는 collector가 단일 topK로 요청하므로 **결합 판정**
- 병합 결과는 다운스트림 `stratifiedSample`이 presetTopK로 캡 → **토큰 안전** (무조건 병합은 RAG 성공 시 관련도 신호를 파괴하므로 금지)

## 부수 변경

`CONTEXT.md` 신설 — 아키텍처 리뷰가 shallow/DRY로 오인하기 쉬운 **load-bearing invariant 4종**을 기록(BullMQ prefix 분기=서비스 격리, control.ts 전역/잡별 큐 스코프, kit domain-agnostic wrapper, 이 게이트 의미론). 미래 리뷰가 의도된 설계를 "낮게 매달린 열매"로 재제안하는 것을 방지합니다.

## 테스트

- `tests/select-analysis-rows.test.ts` — 순수 함수 단위 테스트 6건 (신규, DB mock 불필요)
- `tests/p4-collector-rag.test.ts` — 2건 갱신 (기존 어서션이 옛 버그 동작을 인코딩했었음)
- `tests/subscription-pipeline-regression.test.ts` — `ragSample: []` 사용으로 무영향, 통과 유지

검증 결과: 변경 관련 13/13 통과, `tsc --noEmit` 0 에러, eslint 통과.

### 참고 (무관 사항)
core 전체 스위트에서 `analysis-runner.test.ts`의 "runAnalysisPipeline export" 테스트가 전체 동시 실행 시 dynamic import 부하로 타임아웃하나(격리 시 2.4s 통과), 본 변경(row 선택)과 의미적으로 무관한 known 느린 테스트입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)