### PR TITLE
feat: 유튜브 자막 스크래퍼 차단 회로 차단기 + 자동 스킵 토글

### DIFF
--- a/apps/collector/src/db/schema/subscriptions.ts
+++ b/apps/collector/src/db/schema/subscriptions.ts
@@ -17,6 +17,7 @@ export type SubscriptionLimits = {
 
 export type SubscriptionOptions = {
   collectTranscript?: boolean;
+  transcriptAutoSkipOnBlock?: boolean;
   includeComments?: boolean;
   enableManipulation?: boolean;
 };

--- a/apps/collector/src/queue/executor.ts
+++ b/apps/collector/src/queue/executor.ts
@@ -175,6 +175,7 @@ export async function executeCollectionJob(
       maxItemsPerDay: limits.maxPerRun,
       maxComments: limits.commentsPerItem,
       collectTranscript: options?.collectTranscript,
+      transcriptAutoSkipOnBlock: options?.transcriptAutoSkipOnBlock,
       mode: job.data.mode,
     });
 

--- a/apps/collector/src/queue/types.ts
+++ b/apps/collector/src/queue/types.ts
@@ -37,6 +37,7 @@ export interface CollectionJobData {
   };
   options?: {
     collectTranscript?: boolean;
+    transcriptAutoSkipOnBlock?: boolean;
     includeComments?: boolean;
   };
   /** 수집 시간 범위 — 스케줄러는 "직전 수집 이후 ~ 지금" 범위를 넘김 */

--- a/apps/collector/src/server/trpc/subscriptions.ts
+++ b/apps/collector/src/server/trpc/subscriptions.ts
@@ -22,6 +22,7 @@ export const limitsSchema = z.object({
 export const optionsSchema = z
   .object({
     collectTranscript: z.boolean().optional(),
+    transcriptAutoSkipOnBlock: z.boolean().optional(),
     includeComments: z.boolean().optional(),
     enableManipulation: z.boolean().optional(),
   })

--- a/apps/web/src/components/analysis/subscription-picker.tsx
+++ b/apps/web/src/components/analysis/subscription-picker.tsx
@@ -12,7 +12,11 @@ export interface SubscriptionSummary {
   keyword: string;
   sources: string[];
   limits: { maxPerRun: number; maxPerDay?: number; commentsPerItem?: number };
-  options: { collectTranscript?: boolean; includeComments?: boolean };
+  options: {
+    collectTranscript?: boolean;
+    transcriptAutoSkipOnBlock?: boolean;
+    includeComments?: boolean;
+  };
   domain?: string | null;
 }
 
@@ -57,6 +61,8 @@ export function SubscriptionPicker({ onSelect, disabled }: SubscriptionPickerPro
       limits: sub.limits,
       options: {
         collectTranscript: sub.options?.collectTranscript ?? false,
+        // undefined(기존 구독)는 활성으로 — 회로 차단기 기본 ON
+        transcriptAutoSkipOnBlock: sub.options?.transcriptAutoSkipOnBlock !== false,
         includeComments: sub.options?.includeComments ?? true,
       },
       domain: sub.domain,

--- a/apps/web/src/components/analysis/trigger-form.tsx
+++ b/apps/web/src/components/analysis/trigger-form.tsx
@@ -105,6 +105,8 @@ export function TriggerForm({ onJobStarted, preset, onChangePreset }: TriggerFor
   const [breakpoints, setBreakpoints] = useState<BreakpointValue[]>([]);
   const [forceRefetch, setForceRefetch] = useState(false);
   const [collectTranscript, setCollectTranscript] = useState(false);
+  // 차단 시 자동 스킵 — 기본 활성 (회로 차단기 ON)
+  const [transcriptAutoSkipOnBlock, setTranscriptAutoSkipOnBlock] = useState(true);
   const [subscriptionMode, setSubscriptionMode] = useState<{
     isActive: boolean;
     subscription: SubscriptionSummary | null;
@@ -220,6 +222,8 @@ export function TriggerForm({ onJobStarted, preset, onChangePreset }: TriggerFor
     setForceRefetch(false);
     setEnableItemAnalysis(sub.options.includeComments !== false);
     setCollectTranscript(!!sub.options.collectTranscript);
+    // undefined(기존 구독)는 활성으로 복원 — 회로 차단기 기본 ON
+    setTranscriptAutoSkipOnBlock(sub.options.transcriptAutoSkipOnBlock !== false);
     if (sub.limits.maxPerRun) {
       setMaxNaverArticles(Math.min(sub.limits.maxPerRun, 5000));
       setMaxYoutubeVideos(Math.min(Math.round(sub.limits.maxPerRun / 10), 500));
@@ -267,6 +271,9 @@ export function TriggerForm({ onJobStarted, preset, onChangePreset }: TriggerFor
               ...(enableItemAnalysis && { enableItemAnalysis: true }),
               ...(optimizationPreset !== 'none' && { tokenOptimization: optimizationPreset }),
               ...(collectTranscript && { collectTranscript: true }),
+              // default-ON — OFF일 때만 명시 전송(자막 수집이 켜진 경우에 한해)
+              ...(collectTranscript &&
+                !transcriptAutoSkipOnBlock && { transcriptAutoSkipOnBlock: false }),
             }
           : undefined,
       limits: {
@@ -393,6 +400,8 @@ export function TriggerForm({ onJobStarted, preset, onChangePreset }: TriggerFor
             onEnableItemAnalysisChange={setEnableItemAnalysis}
             collectTranscript={collectTranscript}
             onCollectTranscriptChange={setCollectTranscript}
+            transcriptAutoSkipOnBlock={transcriptAutoSkipOnBlock}
+            onTranscriptAutoSkipOnBlockChange={setTranscriptAutoSkipOnBlock}
             sources={sources}
           />
 

--- a/apps/web/src/components/analysis/trigger-form/analysis-options.tsx
+++ b/apps/web/src/components/analysis/trigger-form/analysis-options.tsx
@@ -13,6 +13,8 @@ export interface AnalysisOptionsProps {
   onEnableItemAnalysisChange: (v: boolean) => void;
   collectTranscript: boolean;
   onCollectTranscriptChange: (v: boolean) => void;
+  transcriptAutoSkipOnBlock: boolean;
+  onTranscriptAutoSkipOnBlockChange: (v: boolean) => void;
   sources: SourceId[];
 }
 
@@ -24,6 +26,8 @@ export function AnalysisOptions({
   onEnableItemAnalysisChange,
   collectTranscript,
   onCollectTranscriptChange,
+  transcriptAutoSkipOnBlock,
+  onTranscriptAutoSkipOnBlockChange,
   sources,
 }: AnalysisOptionsProps) {
   return (
@@ -74,6 +78,26 @@ export function AnalysisOptions({
             <p className="text-xs text-muted-foreground">
               영상 자막을 수집합니다. YouTube 자막이 없는 영상은 조회수 상위 20건에 한해 오디오를
               자동 전사(Whisper)해 채웁니다. 다음 분석 실행부터 반영됩니다.
+            </p>
+          </div>
+        </label>
+      )}
+      {sources.includes('youtube') && collectTranscript && (
+        <label
+          className={`ml-6 flex items-start gap-2 rounded-lg border p-3 transition-colors ${isDemo ? 'opacity-70' : 'cursor-pointer hover:bg-accent/50'}`}
+        >
+          <Checkbox
+            checked={transcriptAutoSkipOnBlock}
+            onCheckedChange={(checked) => onTranscriptAutoSkipOnBlockChange(!!checked)}
+            disabled={isDemo || disabled || isSubMode}
+            className="mt-0.5"
+          />
+          <div className="space-y-1">
+            <span className="text-sm font-medium">차단 시 자동 스킵</span>
+            <p className="text-xs text-muted-foreground">
+              YouTube가 자막 요청을 차단(429)하면, 그 수집 회차의 나머지 영상은 자막 호출을 건너뛰고
+              Whisper·설명문 폴백으로 진행합니다. 끄면 차단돼도 모든 영상에서 자막을 계속
+              시도합니다(권장하지 않음).
             </p>
           </div>
         </label>

--- a/apps/web/src/components/subscriptions/analyze/subscription-select-step.tsx
+++ b/apps/web/src/components/subscriptions/analyze/subscription-select-step.tsx
@@ -50,6 +50,8 @@ export function SubscriptionSelectStep({ onSelect }: SubscriptionSelectStepProps
       limits: sub.limits,
       options: {
         collectTranscript: sub.options?.collectTranscript ?? false,
+        // undefined(기존 구독)는 활성으로 — 회로 차단기 기본 ON
+        transcriptAutoSkipOnBlock: sub.options?.transcriptAutoSkipOnBlock !== false,
         includeComments: sub.options?.includeComments ?? true,
       },
       domain: sub.domain,

--- a/apps/web/src/components/subscriptions/subscription-form.tsx
+++ b/apps/web/src/components/subscriptions/subscription-form.tsx
@@ -82,6 +82,10 @@ export function SubscriptionForm({ initial, onSaved, onCreated, onCancel }: Subs
   const [collectTranscript, setCollectTranscript] = useState(
     initial?.options?.collectTranscript ?? false,
   );
+  // 차단 시 자동 스킵 — undefined(기존 구독)는 활성 (회로 차단기 기본 ON)
+  const [transcriptAutoSkipOnBlock, setTranscriptAutoSkipOnBlock] = useState(
+    initial?.options?.transcriptAutoSkipOnBlock !== false,
+  );
   const [enableManipulation, setEnableManipulation] = useState(
     initial?.options?.enableManipulation ?? false,
   );
@@ -99,7 +103,11 @@ export function SubscriptionForm({ initial, onSaved, onCreated, onCancel }: Subs
       sources: string[];
       intervalHours: number;
       limits: { maxPerRun: number; commentsPerItem: number };
-      options?: { collectTranscript?: boolean; enableManipulation?: boolean };
+      options?: {
+        collectTranscript?: boolean;
+        transcriptAutoSkipOnBlock?: boolean;
+        enableManipulation?: boolean;
+      };
     }) =>
       trpcClient.subscriptions.create.mutate({
         keyword: input.keyword,
@@ -124,7 +132,11 @@ export function SubscriptionForm({ initial, onSaved, onCreated, onCancel }: Subs
       sources: string[];
       intervalHours: number;
       limits: { maxPerRun: number; commentsPerItem: number };
-      options?: { collectTranscript?: boolean; enableManipulation?: boolean };
+      options?: {
+        collectTranscript?: boolean;
+        transcriptAutoSkipOnBlock?: boolean;
+        enableManipulation?: boolean;
+      };
     }) =>
       trpcClient.subscriptions.update.mutate({
         id: input.id,
@@ -182,6 +194,7 @@ export function SubscriptionForm({ initial, onSaved, onCreated, onCancel }: Subs
       limits: { maxPerRun, commentsPerItem },
       options: {
         collectTranscript,
+        transcriptAutoSkipOnBlock,
         enableManipulation,
       },
     };
@@ -400,6 +413,24 @@ export function SubscriptionForm({ initial, onSaved, onCreated, onCancel }: Subs
             <p className="text-xs text-muted-foreground">
               영상 자막을 수집합니다. YouTube 자막이 없는 영상은 조회수 상위 20건에 한해 오디오를
               자동 전사(Whisper)해 채웁니다. 다음 분석 실행부터 반영됩니다.
+            </p>
+          </div>
+        </label>
+      )}
+      {sources.includes('youtube') && collectTranscript && (
+        <label className="ml-6 flex items-start gap-2 rounded-lg border p-3 cursor-pointer hover:bg-accent/50">
+          <Checkbox
+            checked={transcriptAutoSkipOnBlock}
+            onCheckedChange={(checked) => setTranscriptAutoSkipOnBlock(!!checked)}
+            disabled={isPending}
+            className="mt-0.5"
+          />
+          <div className="space-y-1">
+            <span className="text-sm font-medium">차단 시 자동 스킵</span>
+            <p className="text-xs text-muted-foreground">
+              YouTube가 자막 요청을 차단(429)하면, 그 수집 회차의 나머지 영상은 자막 호출을 건너뛰고
+              Whisper·설명문 폴백으로 진행합니다. 끄면 차단돼도 모든 영상에서 자막을 계속
+              시도합니다(권장하지 않음).
             </p>
           </div>
         </label>

--- a/apps/web/src/server/trpc/routers/analysis.ts
+++ b/apps/web/src/server/trpc/routers/analysis.ts
@@ -49,6 +49,7 @@ export const analysisRouter = router({
               ])
               .optional(),
             collectTranscript: z.boolean().optional(),
+            transcriptAutoSkipOnBlock: z.boolean().optional(),
           })
           .optional(),
         limits: z
@@ -292,6 +293,7 @@ export const analysisRouter = router({
           limitMode,
           forceRefetch: effectiveForceRefetch,
           collectTranscript: input.options?.collectTranscript,
+          transcriptAutoSkipOnBlock: input.options?.transcriptAutoSkipOnBlock,
         },
         job.id,
       );

--- a/apps/web/src/server/trpc/routers/subscriptions.ts
+++ b/apps/web/src/server/trpc/routers/subscriptions.ts
@@ -15,6 +15,7 @@ export interface SubscriptionRecord {
   limits: { maxPerRun: number; maxPerDay?: number; commentsPerItem?: number };
   options?: {
     collectTranscript?: boolean;
+    transcriptAutoSkipOnBlock?: boolean;
     includeComments?: boolean;
     enableManipulation?: boolean;
   } | null;
@@ -245,6 +246,7 @@ const limitsSchema = z.object({
 const optionsSchema = z
   .object({
     collectTranscript: z.boolean().optional(),
+    transcriptAutoSkipOnBlock: z.boolean().optional(),
     includeComments: z.boolean().optional(),
     enableManipulation: z.boolean().optional(),
   })

--- a/docs/superpowers/plans/2026-06-27-youtube-transcript-circuit-breaker.md
+++ b/docs/superpowers/plans/2026-06-27-youtube-transcript-circuit-breaker.md
@@ -1,0 +1,433 @@
+# YouTube 자막 스크래퍼 Run 단위 회로 차단기 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** YouTube 자막 스크래퍼가 429/403 차단을 run 내에서 2회 누적하면 그 run의 나머지 영상은 자막 호출을 스킵하고 Whisper/description 폴백으로 진행하게 한다.
+
+**Architecture:** `fetchTranscript`의 반환 타입을 판별 유니온(`TranscriptResult`)으로 바꿔 차단 여부를 신호로 노출한다. collect 루프 스코프에 회로 상태를 두고, 순수 함수 `evaluateTranscriptCircuit`로 상태를 전이한다. 회로 발동 여부와 스킵 수는 `CollectionStats`로 노출한다.
+
+**Tech Stack:** TypeScript, Vitest, pnpm 모노레포 (`@ai-signalcraft/collectors`)
+
+## Global Constraints
+
+- 패키지: `@ai-signalcraft/collectors` (`packages/collectors/`)
+- 테스트 실행: `pnpm --filter @ai-signalcraft/collectors test` (내부적으로 `TZ=Asia/Seoul vitest run`)
+- 테스트 파일 위치: `packages/collectors/tests/`
+- `fetchTranscript` 호출처는 단 한 곳: `packages/collectors/src/adapters/youtube-collector.ts:131`
+- 임계치 상수: `TRANSCRIPT_BLOCK_THRESHOLD = 2`
+- `blocked: true` 판정 기준: HTTP status가 **429 또는 403**
+- 불변 패턴 준수 (회로 상태는 스프레드로 새 객체 반환)
+- DB 옵션·UI·tRPC 스키마·executor Whisper 폴백은 변경 금지
+
+---
+
+### Task 1: `fetchTranscript` 반환 타입을 판별 유니온으로 변경
+
+**Files:**
+
+- Modify: `packages/collectors/src/utils/youtube-transcript.ts`
+- Test: `packages/collectors/tests/youtube-transcript.test.ts` (신규)
+
+**Interfaces:**
+
+- Consumes: (없음)
+- Produces:
+
+  ```typescript
+  export type TranscriptResult =
+    | { ok: true; text: string; lang: string }
+    | { ok: false; blocked: boolean };
+  export async function fetchTranscript(videoId: string): Promise<TranscriptResult>;
+  ```
+
+  `blocked: true`는 player/captions fetch status가 429 또는 403일 때. `no_tracks`/`parse_empty`/`exception`은 `blocked: false`.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`packages/collectors/tests/youtube-transcript.test.ts` 생성:
+
+```typescript
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchTranscript } from '../src/utils/youtube-transcript';
+
+// player API 정상 응답(자막 트랙 1개) 헬퍼
+function playerOkResponse(baseUrl: string) {
+  return {
+    ok: true,
+    json: async () => ({
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [{ languageCode: 'ko', baseUrl }],
+        },
+      },
+    }),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchTranscript 반환 신호 분류', () => {
+  it('정상 자막은 ok:true와 text/lang을 반환', async () => {
+    const xml = '<p start="0">안녕하세요</p><p start="1">반갑습니다</p>';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(playerOkResponse('https://timedtext.example/ko'))
+        .mockResolvedValueOnce({ ok: true, text: async () => xml }),
+    );
+    const result = await fetchTranscript('vid1');
+    expect(result).toEqual({ ok: true, text: '안녕하세요 반갑습니다', lang: 'ko' });
+  });
+
+  it('captions fetch 429는 ok:false, blocked:true', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(playerOkResponse('https://timedtext.example/ko'))
+        .mockResolvedValueOnce({ ok: false, status: 429 }),
+    );
+    const result = await fetchTranscript('vid2');
+    expect(result).toEqual({ ok: false, blocked: true });
+  });
+
+  it('captions fetch 403도 blocked:true', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(playerOkResponse('https://timedtext.example/ko'))
+        .mockResolvedValueOnce({ ok: false, status: 403 }),
+    );
+    const result = await fetchTranscript('vid3');
+    expect(result).toEqual({ ok: false, blocked: true });
+  });
+
+  it('자막 없는 영상(no_tracks)은 blocked:false', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ captions: undefined }),
+      }),
+    );
+    const result = await fetchTranscript('vid4');
+    expect(result).toEqual({ ok: false, blocked: false });
+  });
+
+  it('player API 429는 blocked:true', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ ok: false, status: 429 }));
+    const result = await fetchTranscript('vid5');
+    expect(result).toEqual({ ok: false, blocked: true });
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors test youtube-transcript`
+Expected: FAIL — 현재 `fetchTranscript`는 `{text, lang} | null`을 반환하므로 `toEqual({ ok: true, ... })`에서 실패.
+
+- [ ] **Step 3: 반환 타입 구현**
+
+`packages/collectors/src/utils/youtube-transcript.ts`를 수정한다. `FailReason` 타입 위(16행 부근)에 export 타입을 추가:
+
+```typescript
+export type TranscriptResult =
+  | { ok: true; text: string; lang: string }
+  | { ok: false; blocked: boolean };
+
+// 429/403은 rate-limit/PO token 차단으로 간주
+function isBlockedStatus(status: number): boolean {
+  return status === 429 || status === 403;
+}
+```
+
+`fetchTranscript` 본문의 각 `return null`을 다음으로 교체한다 (로그 호출 `logFailure`는 그대로 유지):
+
+- `player_http_error` 분기 (현재 57-58행):
+  ```typescript
+  if (!resp.ok) {
+    logFailure(videoId, 'player_http_error', `status=${resp.status}`);
+    return { ok: false, blocked: isBlockedStatus(resp.status) };
+  }
+  ```
+- `no_tracks` 분기 (현재 65-69행):
+  ```typescript
+  if (!tracks?.length) {
+    logFailure(videoId, 'no_tracks');
+    return { ok: false, blocked: false };
+  }
+  ```
+- `captions_http_error` 분기 (현재 75-82행):
+  ```typescript
+  if (!xmlResp.ok) {
+    logFailure(
+      videoId,
+      'captions_http_error',
+      `status=${xmlResp.status} lang=${selected.languageCode}`,
+    );
+    return { ok: false, blocked: isBlockedStatus(xmlResp.status) };
+  }
+  ```
+- `parse_empty` 분기 (현재 92-95행):
+  ```typescript
+  if (texts.length === 0) {
+    logFailure(videoId, 'parse_empty', `xml_bytes=${xml.length} lang=${selected.languageCode}`);
+    return { ok: false, blocked: false };
+  }
+  ```
+- 성공 분기 (현재 97-100행):
+  ```typescript
+  return {
+    ok: true,
+    text: texts.join(' '),
+    lang: selected.languageCode === 'ko' ? 'ko' : selected.languageCode,
+  };
+  ```
+- `catch` 분기 (현재 101-105행):
+  ```typescript
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[transcript] ${videoId} reason=exception ${msg}`);
+    return { ok: false, blocked: false };
+  }
+  ```
+
+함수 시그니처도 변경:
+
+```typescript
+export async function fetchTranscript(videoId: string): Promise<TranscriptResult> {
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors test youtube-transcript`
+Expected: PASS (5개 테스트)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add packages/collectors/src/utils/youtube-transcript.ts packages/collectors/tests/youtube-transcript.test.ts
+git commit -m "feat: fetchTranscript 반환을 판별 유니온으로 — 429/403 차단 신호 노출"
+```
+
+---
+
+### Task 2: 회로 차단기 순수 함수 + 호출처 연결
+
+**Files:**
+
+- Modify: `packages/collectors/src/adapters/youtube-collector.ts` (import 5행, 영상 루프 126-137행, stats 151-160행, 회로 함수 신규)
+- Modify: `packages/collectors/src/adapters/base.ts` (`CollectionStats` 인터페이스 63행)
+- Test: `packages/collectors/tests/youtube-transcript-circuit.test.ts` (신규)
+
+**Interfaces:**
+
+- Consumes (Task 1에서):
+  ```typescript
+  type TranscriptResult =
+    | { ok: true; text: string; lang: string }
+    | { ok: false; blocked: boolean };
+  ```
+- Produces:
+
+  ```typescript
+  export type CircuitState = { blockedCount: number; open: boolean; skipped: number };
+  export function evaluateTranscriptCircuit(
+    state: CircuitState,
+    result: TranscriptResult,
+    threshold: number,
+  ): CircuitState;
+  ```
+
+  `result.ok || !result.blocked`이면 상태 불변. 차단이면 `blockedCount + 1`, `threshold` 도달 시 `open: true`. `open`으로 막혀 스킵된 건수는 호출 루프가 `skipped`에 누적(이 함수가 아니라 루프에서).
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`packages/collectors/tests/youtube-transcript-circuit.test.ts` 생성:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { evaluateTranscriptCircuit, type CircuitState } from '../src/adapters/youtube-collector';
+
+const INITIAL: CircuitState = { blockedCount: 0, open: false, skipped: 0 };
+const THRESHOLD = 2;
+
+describe('evaluateTranscriptCircuit', () => {
+  it('성공 결과는 상태를 바꾸지 않는다', () => {
+    const next = evaluateTranscriptCircuit(INITIAL, { ok: true, text: 'x', lang: 'ko' }, THRESHOLD);
+    expect(next).toEqual(INITIAL);
+  });
+
+  it('no_tracks(blocked:false)는 blockedCount를 올리지 않는다', () => {
+    const next = evaluateTranscriptCircuit(INITIAL, { ok: false, blocked: false }, THRESHOLD);
+    expect(next.blockedCount).toBe(0);
+    expect(next.open).toBe(false);
+  });
+
+  it('차단 1회는 회로를 열지 않는다', () => {
+    const next = evaluateTranscriptCircuit(INITIAL, { ok: false, blocked: true }, THRESHOLD);
+    expect(next.blockedCount).toBe(1);
+    expect(next.open).toBe(false);
+  });
+
+  it('차단 2회 누적 시 회로가 열린다', () => {
+    const after1 = evaluateTranscriptCircuit(INITIAL, { ok: false, blocked: true }, THRESHOLD);
+    const after2 = evaluateTranscriptCircuit(after1, { ok: false, blocked: true }, THRESHOLD);
+    expect(after2.blockedCount).toBe(2);
+    expect(after2.open).toBe(true);
+  });
+
+  it('이미 열린 회로에 추가 차단이 와도 멱등하게 유지', () => {
+    const open: CircuitState = { blockedCount: 2, open: true, skipped: 0 };
+    const next = evaluateTranscriptCircuit(open, { ok: false, blocked: true }, THRESHOLD);
+    expect(next.open).toBe(true);
+    expect(next.blockedCount).toBe(3);
+  });
+
+  it('입력 상태를 변형하지 않는다(불변)', () => {
+    const frozen = Object.freeze({ ...INITIAL });
+    expect(() =>
+      evaluateTranscriptCircuit(frozen, { ok: false, blocked: true }, THRESHOLD),
+    ).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors test youtube-transcript-circuit`
+Expected: FAIL — `evaluateTranscriptCircuit`/`CircuitState` export가 없음.
+
+- [ ] **Step 3: 순수 함수 구현**
+
+`packages/collectors/src/adapters/youtube-collector.ts` 상단 import 아래(5행 부근)에서 `TranscriptResult` 타입도 함께 import:
+
+```typescript
+import { fetchTranscript, type TranscriptResult } from '../utils/youtube-transcript';
+```
+
+파일 내 클래스 정의 바깥(상단 import 블록 직후)에 순수 함수와 타입·상수를 추가:
+
+```typescript
+export type CircuitState = { blockedCount: number; open: boolean; skipped: number };
+
+const TRANSCRIPT_BLOCK_THRESHOLD = 2;
+
+/**
+ * 자막 스크래퍼 차단(429/403)을 run 내에서 집계해 회로를 연다.
+ * 성공·no_tracks는 무시. 임계치 도달 시 open=true. 불변 — 새 상태 반환.
+ */
+export function evaluateTranscriptCircuit(
+  state: CircuitState,
+  result: TranscriptResult,
+  threshold: number,
+): CircuitState {
+  if (result.ok || !result.blocked) return state;
+  const blockedCount = state.blockedCount + 1;
+  const open = blockedCount >= threshold;
+  if (open && !state.open) {
+    console.warn(
+      `[transcript] circuit_open run skipping remaining videos (blocked=${blockedCount})`,
+    );
+  }
+  return { ...state, blockedCount, open };
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors test youtube-transcript-circuit`
+Expected: PASS (6개 테스트)
+
+- [ ] **Step 5: collect 루프에 회로 연결 + CollectionStats 확장**
+
+먼저 `packages/collectors/src/adapters/base.ts`의 `CollectionStats` 인터페이스(63행)에서 `usedFallback?: boolean;`(92행) 아래에 두 필드 추가:
+
+```typescript
+  usedFallback?: boolean;
+  /** run 내 자막 차단 회로가 열렸는지 */
+  transcriptCircuitOpen?: boolean;
+  /** 회로 open으로 자막 호출을 스킵한 영상 수 */
+  transcriptSkippedByCircuit?: number;
+```
+
+`youtube-collector.ts`의 `collect()` 메서드에서 영상 루프 시작 전(예: `endReason` 선언 부근 51행 근처)에 회로 상태를 초기화:
+
+```typescript
+let circuit: CircuitState = { blockedCount: 0, open: false, skipped: 0 };
+```
+
+영상 루프 내부(현재 130-136행)를 다음으로 교체:
+
+```typescript
+if (collectTranscript) {
+  if (circuit.open) {
+    circuit = { ...circuit, skipped: circuit.skipped + 1 };
+  } else {
+    const result = await fetchTranscript(video.sourceId);
+    if (result.ok) {
+      video.transcript = result.text;
+      video.transcriptLang = result.lang;
+    }
+    circuit = evaluateTranscriptCircuit(circuit, result, TRANSCRIPT_BLOCK_THRESHOLD);
+  }
+}
+```
+
+stats 객체(현재 151-160행)에 두 필드 추가:
+
+```typescript
+this.stats = {
+  endReason,
+  lastPage,
+  perDayCount,
+  perDayCapSkip: perDayCapSkip || undefined,
+  outOfRange: outOfRange || undefined,
+  quotaUsed: this.quota.getUsed(),
+  quotaRemaining: this.quota.getRemaining(),
+  usedFallback: this.fallbackActive || undefined,
+  transcriptCircuitOpen: circuit.open || undefined,
+  transcriptSkippedByCircuit: circuit.skipped || undefined,
+};
+```
+
+- [ ] **Step 6: 전체 테스트·타입체크·빌드 확인**
+
+Run: `pnpm --filter @ai-signalcraft/collectors test`
+Expected: PASS (기존 + 신규 모두)
+
+Run: `pnpm --filter @ai-signalcraft/collectors build`
+Expected: 타입 에러 없이 빌드 성공 (반환 타입 변경 호환 확인)
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add packages/collectors/src/adapters/youtube-collector.ts packages/collectors/src/adapters/base.ts packages/collectors/tests/youtube-transcript-circuit.test.ts
+git commit -m "feat: 자막 스크래퍼 run 단위 회로 차단기 — 429 2회 누적 시 잔여 영상 스킵"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- 컴포넌트 1 (반환 신호 확장) → Task 1 ✓
+- 컴포넌트 2 (회로 차단기 + 순수 함수) → Task 2 Step 3, 5 ✓
+- 컴포넌트 3 (Run 요약 카운트) → Task 2 Step 5 ✓
+- 테스트 전략 (반환 분류) → Task 1 Step 1 ✓
+- 테스트 전략 (회로 상태 전이) → Task 2 Step 1 ✓
+- "변경하지 않는 것" → DB/UI/executor/tRPC 무변경, 계획에 해당 파일 없음 ✓
+
+**Placeholder scan:** 모든 step에 실제 코드·명령·예상 출력 포함. 플레이스홀더 없음. ✓
+
+**Type consistency:**
+
+- `TranscriptResult`: Task 1 produces, Task 2 consumes — 동일 시그니처 ✓
+- `CircuitState`/`evaluateTranscriptCircuit`: Task 2 정의·사용 일관 ✓
+- `transcriptCircuitOpen`/`transcriptSkippedByCircuit`: base.ts 정의와 stats 사용 일치 ✓

--- a/docs/superpowers/specs/2026-06-27-youtube-transcript-circuit-breaker-design.md
+++ b/docs/superpowers/specs/2026-06-27-youtube-transcript-circuit-breaker-design.md
@@ -1,0 +1,164 @@
+# YouTube 자막 스크래퍼 Run 단위 회로 차단기 설계
+
+- **작성일**: 2026-06-27
+- **브랜치**: fix/rag-fallback-gate-data-loss (또는 신규 브랜치)
+- **상태**: 승인됨, 구현 대기
+
+## 문제
+
+YouTube가 2024–2025 사이 자막 엔드포인트(`api/timedtext`)에 BotGuard/PO token 보호를
+확대하면서, 쿠키·PO token 없이는 자막 다운로드가 HTTP 429로 거부된다.
+
+현재 `fetchTranscript`는 영상마다 개별 호출되며 차단 시 `null`을 반환한 뒤
+다음 영상에서 **또 시도**한다. 차단 상태에서 N개 영상 = N번의 무의미한 429 요청
+→ 차단 심화 + 수집 시간 낭비.
+
+## 결정 사항 (브레인스토밍 합의)
+
+1. **차단 시 자동 스킵** — 옵션 우회 수단(쿠키·프록시) 추가가 아님
+2. **Run 단위 회로 차단기** — 한 run 내에서 429를 임계치만큼 맞으면 그 run의
+   나머지 영상은 자막 호출을 아예 스킵
+3. **DB 옵션은 유지, 런타임만 스킵** — `subscriptions.options.collectTranscript`를
+   건드리지 않는다. 다음 run에서 자동 재시도 (차단이 풀릴 수 있으므로). 사용자 설정 존중.
+4. **로그 + run 요약 카운트** — 회로 차단 발동을 로그로 남기고, run stats에
+   스킵된 자막 수를 실어 운영자가 "자막이 왜 안 쌓였지"를 파악하게 한다.
+
+## 해결 방향
+
+사용자 설정(`collectTranscript`)은 그대로 두고, **run(=collect 1회 실행) 스코프에서만**
+회로 차단기를 둔다. 차단을 임계치만큼 맞으면 그 run의 나머지 영상은 자막 호출을
+스킵하고, 기존 Whisper/description 폴백으로 진행한다.
+
+## 컴포넌트
+
+### 1. `fetchTranscript` 반환 신호 확장
+
+**파일**: `packages/collectors/src/utils/youtube-transcript.ts`
+
+현재는 성공 시 `{text, lang}`, 실패 시 `null`만 반환한다. 회로 차단기가
+"차단(429) vs 단순 자막 없음(no_tracks)"을 구분하려면 실패 사유가 필요하다.
+
+모듈 주석의 "인터페이스를 유지한다" 의도를 존중해, 반환 타입을 깨지 않는 방식으로
+차단 신호만 추가한다:
+
+```typescript
+type TranscriptResult = { ok: true; text: string; lang: string } | { ok: false; blocked: boolean }; // blocked=true: 429/403 rate-limit, false: no_tracks 등
+```
+
+- `captions_http_error`·`player_http_error`의 status가 **429 또는 403**일 때만 `blocked: true`
+- `no_tracks`/`parse_empty`/`exception`은 `blocked: false`
+- 기존 로그(`logFailure`)는 그대로 유지
+
+### 2. 회로 차단기 (collect 루프)
+
+**파일**: `packages/collectors/src/adapters/youtube-collector.ts` (영상 루프 126-137행)
+
+회로 상태를 **`collect` 메서드 스코프의 지역 변수**로 둔다 (모듈 전역 아님 —
+동시 run 간 오염 방지).
+
+```typescript
+// collect() 시작 부분 (루프 바깥)
+const TRANSCRIPT_BLOCK_THRESHOLD = 2; // 429 2회 누적 시 회로 open
+let circuit = { blockedCount: 0, open: false, skipped: 0 };
+```
+
+루프 내부에서 순수 함수로 상태를 전이한다:
+
+```typescript
+if (collectTranscript) {
+  if (circuit.open) {
+    circuit = { ...circuit, skipped: circuit.skipped + 1 }; // 호출 자체 스킵
+  } else {
+    const result = await fetchTranscript(video.sourceId);
+    if (result.ok) {
+      video.transcript = result.text;
+      video.transcriptLang = result.lang;
+    }
+    circuit = evaluateTranscriptCircuit(circuit, result, TRANSCRIPT_BLOCK_THRESHOLD);
+  }
+}
+```
+
+#### 순수 함수 추출 (테스트 용이성)
+
+회로 로직을 제너레이터에 인라인으로 묻지 않고 작은 불변 함수로 추출한다:
+
+```typescript
+type CircuitState = { blockedCount: number; open: boolean; skipped: number };
+
+function evaluateTranscriptCircuit(
+  state: CircuitState,
+  result: TranscriptResult,
+  threshold: number,
+): CircuitState {
+  if (result.ok || !result.blocked) return state; // 성공·no_tracks는 카운트 안 함
+  const blockedCount = state.blockedCount + 1;
+  const open = blockedCount >= threshold;
+  if (open && !state.open) {
+    console.warn(
+      `[transcript] circuit_open run skipping remaining videos (blocked=${blockedCount})`,
+    );
+  }
+  return { ...state, blockedCount, open };
+}
+```
+
+회로가 열려도 executor의 Whisper 폴백은 자동 작동한다 — `transcript === ''`인 영상을
+Whisper 후보로 누적하는 로직(`executor.ts:204-219`)은 자막 스킵 여부와 무관하기 때문.
+
+### 3. Run 요약 카운트 (CollectionStats)
+
+**파일**: `packages/collectors/src/adapters/base.ts` (`CollectionStats` 인터페이스, 63행)
+
+```typescript
+export interface CollectionStats {
+  // ... 기존 필드
+  transcriptCircuitOpen?: boolean;
+  transcriptSkippedByCircuit?: number;
+}
+```
+
+**파일**: `youtube-collector.ts` (stats 객체, 151-160행) — 기존 `|| undefined` 패턴에 맞춰 채운다:
+
+```typescript
+this.stats = {
+  // ...
+  transcriptCircuitOpen: circuit.open || undefined,
+  transcriptSkippedByCircuit: circuit.skipped || undefined,
+};
+```
+
+## 테스트 전략
+
+### `youtube-transcript.test.ts` (신규) — 반환 신호 분류
+
+- 429 응답 → `{ ok: false, blocked: true }`
+- 403 응답 → `{ ok: false, blocked: true }`
+- `no_tracks` (빈 captionTracks) → `{ ok: false, blocked: false }`
+- 정상 자막 → `{ ok: true, text, lang }`
+
+### 회로 차단기 테스트 (신규) — `evaluateTranscriptCircuit` 상태 전이
+
+- 429를 임계치(2회) 맞으면 `open: true`
+- `no_tracks`(blocked=false)는 `blockedCount` 증가 안 함 → 회로 안 열림
+- 성공 결과는 상태 불변
+- 임계치 도달 후 추가 호출은 상태 유지 (멱등)
+
+## 변경하지 않는 것
+
+- **DB 옵션** `subscriptions.options.collectTranscript`
+- **UI 토글** (`analysis-options.tsx`)
+- **executor의 Whisper 폴백** (자동으로 폴백 경로로 흐름)
+- **tRPC 스키마**
+
+`fetchTranscript`의 호출처는 단 한 곳(`youtube-collector.ts:131`)으로 grep 확인됨.
+
+## 변경 파일 요약
+
+| 파일                                                    | 변경                                                                            |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `packages/collectors/src/utils/youtube-transcript.ts`   | 반환 타입을 `TranscriptResult` 판별 유니온으로, 429/403 시 `blocked: true`      |
+| `packages/collectors/src/adapters/youtube-collector.ts` | collect 루프에 회로 차단기, `evaluateTranscriptCircuit` 순수 함수, stats 카운트 |
+| `packages/collectors/src/adapters/base.ts`              | `CollectionStats`에 `transcriptCircuitOpen?`, `transcriptSkippedByCircuit?`     |
+| `youtube-transcript.test.ts` (신규)                     | 반환 신호 분류 테스트                                                           |
+| 회로 테스트 (신규)                                      | `evaluateTranscriptCircuit` 상태 전이 테스트                                    |

--- a/packages/collectors/src/adapters/base.ts
+++ b/packages/collectors/src/adapters/base.ts
@@ -90,6 +90,10 @@ export interface CollectionStats {
   quotaRemaining?: number;
   /** 폴백 전략 사용 여부 */
   usedFallback?: boolean;
+  /** run 내 자막 차단(429/403) 회로가 열렸는지 (YouTube 전용) */
+  transcriptCircuitOpen?: boolean;
+  /** 회로 open으로 자막 호출을 스킵한 영상 수 (YouTube 전용) */
+  transcriptSkippedByCircuit?: number;
 }
 
 // 모든 수집기가 구현하는 인터페이스

--- a/packages/collectors/src/adapters/base.ts
+++ b/packages/collectors/src/adapters/base.ts
@@ -41,6 +41,9 @@ export const CollectionOptionsSchema = z.object({
   since: z.string().datetime().optional(),
   commentOrder: z.enum(['relevance', 'time']).default('relevance').optional(),
   collectTranscript: z.boolean().default(true).optional(),
+  // 자막 차단(429/403)이 누적되면 run 잔여 영상의 자막 호출을 자동 스킵.
+  // undefined/true = 활성(권장). false = 차단돼도 모든 영상에서 자막 재시도(비권장).
+  transcriptAutoSkipOnBlock: z.boolean().default(true).optional(),
 });
 export type CollectionOptions = z.infer<typeof CollectionOptionsSchema>;
 

--- a/packages/collectors/src/adapters/youtube-collector.ts
+++ b/packages/collectors/src/adapters/youtube-collector.ts
@@ -2,7 +2,7 @@
 import { getYoutubeClient, YoutubeApiKeyMissingError } from '../utils/youtube-client';
 import { getInnertubeClient } from '../utils/youtube-innertube';
 import { QuotaTracker } from '../utils/youtube-quota';
-import { fetchTranscript } from '../utils/youtube-transcript';
+import { fetchTranscript, type TranscriptResult } from '../utils/youtube-transcript';
 import { splitIntoDaysKst, KST_OFFSET_MS } from '../utils/community-parser';
 import type { Collector, CollectionOptions, CollectionStats } from './base';
 import { parseYoutubeDuration, type YoutubeVideo } from './youtube-videos';
@@ -15,6 +15,34 @@ const SEARCH_PAGE_SIZE = 50;
 const COMMENTS_PAGE_SIZE = 100;
 // 쿼터 임계값 — search 1회(100유닛) 미만이면 fallback 전환
 const QUOTA_FALLBACK_THRESHOLD = 150;
+
+// ─── 자막 차단 회로 차단기 ───
+// YouTube가 PO token 없는 자막 요청을 429/403으로 거부하면, 한 run 내에서 영상마다
+// 똑같이 차단당하므로 무의미한 재요청이 누적된다. 임계치만큼 차단을 맞으면 회로를 열어
+// 그 run의 잔여 영상은 자막 호출을 스킵한다(Whisper/description 폴백은 그대로 작동).
+export type CircuitState = { blockedCount: number; open: boolean; skipped: number };
+
+const TRANSCRIPT_BLOCK_THRESHOLD = 2;
+
+/**
+ * 자막 스크래퍼 차단(429/403)을 run 내에서 집계해 회로를 연다.
+ * 성공·no_tracks는 무시. 임계치 도달 시 open=true. 불변 — 새 상태를 반환한다.
+ */
+export function evaluateTranscriptCircuit(
+  state: CircuitState,
+  result: TranscriptResult,
+  threshold: number,
+): CircuitState {
+  if (result.ok || !result.blocked) return state;
+  const blockedCount = state.blockedCount + 1;
+  const open = blockedCount >= threshold;
+  if (open && !state.open) {
+    console.warn(
+      `[transcript] circuit_open run skipping remaining videos (blocked=${blockedCount})`,
+    );
+  }
+  return { ...state, blockedCount, open };
+}
 
 /**
  * YoutubeCollector — 통합 수집기
@@ -50,6 +78,8 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
     let totalCollected = 0;
     let endReason: CollectionStats['endReason'] = 'completed';
     let lastPage = 0;
+    // 자막 차단 회로 — run 스코프(동시 run 간 오염 방지)
+    let circuit: CircuitState = { blockedCount: 0, open: false, skipped: 0 };
     let perDayCapSkip = 0;
     let outOfRange = 0;
 
@@ -128,10 +158,16 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
             video.comments = await this.collectComments(video.sourceId, maxComments, commentOrder);
           }
           if (collectTranscript) {
-            const transcript = await fetchTranscript(video.sourceId);
-            if (transcript) {
-              video.transcript = transcript.text;
-              video.transcriptLang = transcript.lang;
+            if (circuit.open) {
+              // 회로 열림 — 호출 자체를 스킵 (Whisper/description 폴백으로 진행)
+              circuit = { ...circuit, skipped: circuit.skipped + 1 };
+            } else {
+              const result = await fetchTranscript(video.sourceId);
+              if (result.ok) {
+                video.transcript = result.text;
+                video.transcriptLang = result.lang;
+              }
+              circuit = evaluateTranscriptCircuit(circuit, result, TRANSCRIPT_BLOCK_THRESHOLD);
             }
           }
         }
@@ -157,6 +193,8 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
       quotaUsed: this.quota.getUsed(),
       quotaRemaining: this.quota.getRemaining(),
       usedFallback: this.fallbackActive || undefined,
+      transcriptCircuitOpen: circuit.open || undefined,
+      transcriptSkippedByCircuit: circuit.skipped || undefined,
     };
   }
 

--- a/packages/collectors/src/adapters/youtube-collector.ts
+++ b/packages/collectors/src/adapters/youtube-collector.ts
@@ -65,6 +65,8 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
     const maxComments = options.maxComments ?? DEFAULT_MAX_COMMENTS;
     const commentOrder = options.commentOrder ?? 'relevance';
     const collectTranscript = options.collectTranscript !== false;
+    // 차단 자동 스킵 — undefined(기존 구독)는 활성으로 간주 (회로 차단기 유지)
+    const transcriptCircuitEnabled = options.transcriptAutoSkipOnBlock !== false;
     const days = splitIntoDaysKst(options.startDate, options.endDate);
     const perDayLimit = options.maxItemsPerDay ?? Math.max(1, Math.floor(maxItems / days.length));
     const skipUrlSet = new Set(options.reusePlan?.skipUrls ?? []);
@@ -158,7 +160,7 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
             video.comments = await this.collectComments(video.sourceId, maxComments, commentOrder);
           }
           if (collectTranscript) {
-            if (circuit.open) {
+            if (transcriptCircuitEnabled && circuit.open) {
               // 회로 열림 — 호출 자체를 스킵 (Whisper/description 폴백으로 진행)
               circuit = { ...circuit, skipped: circuit.skipped + 1 };
             } else {
@@ -167,7 +169,10 @@ export class YoutubeCollector implements Collector<YoutubeVideo> {
                 video.transcript = result.text;
                 video.transcriptLang = result.lang;
               }
-              circuit = evaluateTranscriptCircuit(circuit, result, TRANSCRIPT_BLOCK_THRESHOLD);
+              // 자동 스킵 OFF면 회로를 열지 않음 — 모든 영상에서 계속 시도
+              if (transcriptCircuitEnabled) {
+                circuit = evaluateTranscriptCircuit(circuit, result, TRANSCRIPT_BLOCK_THRESHOLD);
+              }
             }
           }
         }

--- a/packages/collectors/src/utils/youtube-transcript.ts
+++ b/packages/collectors/src/utils/youtube-transcript.ts
@@ -15,6 +15,17 @@ type FailReason =
   | 'captions_http_error' // baseUrl fetch 실패 — 대부분 429 (PO token)
   | 'parse_empty'; // XML은 받았지만 <p> 세그먼트 파싱 실패
 
+// 성공 시 자막을, 실패 시 차단 여부를 노출하는 판별 유니온.
+// blocked=true는 run 단위 회로 차단기(youtube-collector.ts)의 트리거가 된다.
+export type TranscriptResult =
+  | { ok: true; text: string; lang: string }
+  | { ok: false; blocked: boolean };
+
+// 429/403은 rate-limit/PO token 차단으로 간주. no_tracks 등은 차단이 아님.
+function isBlockedStatus(status: number): boolean {
+  return status === 429 || status === 403;
+}
+
 function logFailure(videoId: string, reason: FailReason, detail?: string): void {
   // 운영 환경에서 구조화된 grep이 가능하도록 고정 prefix 사용.
   // 향후 재활성화 시도 시 reason별 빈도를 집계해 원인을 판별한다.
@@ -35,9 +46,7 @@ function decodeEntities(text: string): string {
     .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)));
 }
 
-export async function fetchTranscript(
-  videoId: string,
-): Promise<{ text: string; lang: string } | null> {
+export async function fetchTranscript(videoId: string): Promise<TranscriptResult> {
   try {
     const resp = await fetch(INNERTUBE_PLAYER_URL, {
       method: 'POST',
@@ -55,7 +64,7 @@ export async function fetchTranscript(
 
     if (!resp.ok) {
       logFailure(videoId, 'player_http_error', `status=${resp.status}`);
-      return null;
+      return { ok: false, blocked: isBlockedStatus(resp.status) };
     }
 
     const data = await resp.json();
@@ -65,7 +74,7 @@ export async function fetchTranscript(
     if (!tracks?.length) {
       // 자막이 원래 없는 영상이 다수이므로 흔한 케이스 — 로그 남기되 집계는 의미 있음
       logFailure(videoId, 'no_tracks');
-      return null;
+      return { ok: false, blocked: false };
     }
 
     const koTrack = tracks.find((t) => t.languageCode === 'ko');
@@ -78,7 +87,7 @@ export async function fetchTranscript(
         'captions_http_error',
         `status=${xmlResp.status} lang=${selected.languageCode}`,
       );
-      return null;
+      return { ok: false, blocked: isBlockedStatus(xmlResp.status) };
     }
 
     const xml = await xmlResp.text();
@@ -91,16 +100,17 @@ export async function fetchTranscript(
 
     if (texts.length === 0) {
       logFailure(videoId, 'parse_empty', `xml_bytes=${xml.length} lang=${selected.languageCode}`);
-      return null;
+      return { ok: false, blocked: false };
     }
 
     return {
+      ok: true,
       text: texts.join(' '),
       lang: selected.languageCode === 'ko' ? 'ko' : selected.languageCode,
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`[transcript] ${videoId} reason=exception ${msg}`);
-    return null;
+    return { ok: false, blocked: false };
   }
 }

--- a/packages/collectors/tests/youtube-transcript-circuit.test.ts
+++ b/packages/collectors/tests/youtube-transcript-circuit.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateTranscriptCircuit, type CircuitState } from '../src/adapters/youtube-collector';
+
+const INITIAL: CircuitState = { blockedCount: 0, open: false, skipped: 0 };
+const THRESHOLD = 2;
+
+describe('evaluateTranscriptCircuit', () => {
+  it('성공 결과는 상태를 바꾸지 않는다', () => {
+    const next = evaluateTranscriptCircuit(INITIAL, { ok: true, text: 'x', lang: 'ko' }, THRESHOLD);
+    expect(next).toEqual(INITIAL);
+  });
+
+  it('no_tracks(blocked:false)는 blockedCount를 올리지 않는다', () => {
+    const next = evaluateTranscriptCircuit(INITIAL, { ok: false, blocked: false }, THRESHOLD);
+    expect(next.blockedCount).toBe(0);
+    expect(next.open).toBe(false);
+  });
+
+  it('차단 1회는 회로를 열지 않는다', () => {
+    const next = evaluateTranscriptCircuit(INITIAL, { ok: false, blocked: true }, THRESHOLD);
+    expect(next.blockedCount).toBe(1);
+    expect(next.open).toBe(false);
+  });
+
+  it('차단 2회 누적 시 회로가 열린다', () => {
+    const after1 = evaluateTranscriptCircuit(INITIAL, { ok: false, blocked: true }, THRESHOLD);
+    const after2 = evaluateTranscriptCircuit(after1, { ok: false, blocked: true }, THRESHOLD);
+    expect(after2.blockedCount).toBe(2);
+    expect(after2.open).toBe(true);
+  });
+
+  it('이미 열린 회로에 추가 차단이 와도 멱등하게 유지', () => {
+    const open: CircuitState = { blockedCount: 2, open: true, skipped: 0 };
+    const next = evaluateTranscriptCircuit(open, { ok: false, blocked: true }, THRESHOLD);
+    expect(next.open).toBe(true);
+    expect(next.blockedCount).toBe(3);
+  });
+
+  it('입력 상태를 변형하지 않는다(불변)', () => {
+    const frozen = Object.freeze({ ...INITIAL });
+    expect(() =>
+      evaluateTranscriptCircuit(frozen, { ok: false, blocked: true }, THRESHOLD),
+    ).not.toThrow();
+  });
+});

--- a/packages/collectors/tests/youtube-transcript-circuit.test.ts
+++ b/packages/collectors/tests/youtube-transcript-circuit.test.ts
@@ -43,3 +43,35 @@ describe('evaluateTranscriptCircuit', () => {
     ).not.toThrow();
   });
 });
+
+describe('차단 자동 스킵 게이트 (transcriptCircuitEnabled)', () => {
+  // collect 루프의 게이트 동작 재현: enabled=false면 evaluateTranscriptCircuit를
+  // 호출하지 않으므로, 차단이 아무리 누적돼도 회로가 열리지 않는다.
+  function runLoop(enabled: boolean, results: Array<{ ok: false; blocked: boolean }>) {
+    let circuit: CircuitState = { blockedCount: 0, open: false, skipped: 0 };
+    for (const result of results) {
+      if (enabled && circuit.open) {
+        circuit = { ...circuit, skipped: circuit.skipped + 1 };
+      } else if (enabled) {
+        circuit = evaluateTranscriptCircuit(circuit, result, THRESHOLD);
+      }
+      // enabled=false면 회로 상태를 전혀 건드리지 않음
+    }
+    return circuit;
+  }
+
+  it('게이트 ON: 차단 3회면 회로가 열리고 스킵이 누적된다', () => {
+    const blocked = { ok: false as const, blocked: true };
+    const final = runLoop(true, [blocked, blocked, blocked]);
+    expect(final.open).toBe(true);
+    expect(final.skipped).toBe(1); // 3번째는 이미 open이라 스킵
+  });
+
+  it('게이트 OFF: 차단이 누적돼도 회로가 절대 열리지 않는다', () => {
+    const blocked = { ok: false as const, blocked: true };
+    const final = runLoop(false, [blocked, blocked, blocked, blocked]);
+    expect(final.open).toBe(false);
+    expect(final.blockedCount).toBe(0);
+    expect(final.skipped).toBe(0);
+  });
+});

--- a/packages/collectors/tests/youtube-transcript.test.ts
+++ b/packages/collectors/tests/youtube-transcript.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchTranscript } from '../src/utils/youtube-transcript';
+
+// player API 정상 응답(자막 트랙 1개) 헬퍼
+function playerOkResponse(baseUrl: string) {
+  return {
+    ok: true,
+    json: async () => ({
+      captions: {
+        playerCaptionsTracklistRenderer: {
+          captionTracks: [{ languageCode: 'ko', baseUrl }],
+        },
+      },
+    }),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchTranscript 반환 신호 분류', () => {
+  it('정상 자막은 ok:true와 text/lang을 반환', async () => {
+    const xml = '<p start="0">안녕하세요</p><p start="1">반갑습니다</p>';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(playerOkResponse('https://timedtext.example/ko'))
+        .mockResolvedValueOnce({ ok: true, text: async () => xml }),
+    );
+    const result = await fetchTranscript('vid1');
+    expect(result).toEqual({ ok: true, text: '안녕하세요 반갑습니다', lang: 'ko' });
+  });
+
+  it('captions fetch 429는 ok:false, blocked:true', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(playerOkResponse('https://timedtext.example/ko'))
+        .mockResolvedValueOnce({ ok: false, status: 429 }),
+    );
+    const result = await fetchTranscript('vid2');
+    expect(result).toEqual({ ok: false, blocked: true });
+  });
+
+  it('captions fetch 403도 blocked:true', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(playerOkResponse('https://timedtext.example/ko'))
+        .mockResolvedValueOnce({ ok: false, status: 403 }),
+    );
+    const result = await fetchTranscript('vid3');
+    expect(result).toEqual({ ok: false, blocked: true });
+  });
+
+  it('자막 없는 영상(no_tracks)은 blocked:false', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ captions: undefined }),
+      }),
+    );
+    const result = await fetchTranscript('vid4');
+    expect(result).toEqual({ ok: false, blocked: false });
+  });
+
+  it('player API 429는 blocked:true', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ ok: false, status: 429 }));
+    const result = await fetchTranscript('vid5');
+    expect(result).toEqual({ ok: false, blocked: true });
+  });
+});

--- a/packages/core/src/queue/collector-worker.ts
+++ b/packages/core/src/queue/collector-worker.ts
@@ -107,6 +107,8 @@ export function createCollectorHandler(): (job: Job) => Promise<CollectorResult>
             quotaUsed?: number;
             quotaRemaining?: number;
             usedFallback?: boolean;
+            transcriptCircuitOpen?: boolean;
+            transcriptSkippedByCircuit?: number;
           };
           const distStr = Object.entries(s.perDayCount)
             .sort(([a], [b]) => a.localeCompare(b))
@@ -117,10 +119,14 @@ export function createCollectorHandler(): (job: Job) => Promise<CollectorResult>
               ? ` quota=${s.quotaUsed}/${s.quotaUsed + (s.quotaRemaining ?? 0)}`
               : '';
           const fallbackInfo = s.usedFallback ? ' [innertube-fallback]' : '';
+          // 자막 차단 회로가 열렸으면 스킵 수와 함께 배지 노출 (운영자 진단용)
+          const transcriptCircuitInfo = s.transcriptCircuitOpen
+            ? ` [transcript-circuit-open skipped=${s.transcriptSkippedByCircuit ?? 0}]`
+            : '';
           appendJobEvent(
             dbJobId,
             'info',
-            `[${source}] 종료: reason=${s.endReason} lastPage=${s.lastPage}${quotaInfo}${fallbackInfo} 분포(KST)={${distStr}} capSkip=${s.perDayCapSkip ?? 0} preFilterSkip=${s.preFilterSkip ?? 0} outOfRange=${s.outOfRange ?? 0} pageEmpty=${s.pageEmptyCount ?? 0}`,
+            `[${source}] 종료: reason=${s.endReason} lastPage=${s.lastPage}${quotaInfo}${fallbackInfo}${transcriptCircuitInfo} 분포(KST)={${distStr}} capSkip=${s.perDayCapSkip ?? 0} preFilterSkip=${s.preFilterSkip ?? 0} outOfRange=${s.outOfRange ?? 0} pageEmpty=${s.pageEmptyCount ?? 0}`,
           ).catch((err) => logError('collector-worker', err));
         }
       }

--- a/packages/core/src/queue/flows.ts
+++ b/packages/core/src/queue/flows.ts
@@ -318,6 +318,8 @@ export async function triggerCollection(params: CollectionTrigger, dbJobId: numb
             maxComments: limits.commentsPerItem,
             commentOrder: 'relevance',
             collectTranscript: params.collectTranscript ?? false,
+            // 차단 자동 스킵 — 기본 활성 (undefined → true)
+            transcriptAutoSkipOnBlock: params.transcriptAutoSkipOnBlock ?? true,
             flowId,
             dbJobId,
             reusePlan,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -23,6 +23,8 @@ export const CollectionTriggerSchema = z.object({
   forceRefetch: z.boolean().optional(),
   // YouTube 영상 자막 수집 여부 (기본: false)
   collectTranscript: z.boolean().optional(),
+  // 자막 차단 누적 시 자동 스킵 (기본: 활성). false면 차단돼도 모든 영상 재시도
+  transcriptAutoSkipOnBlock: z.boolean().optional(),
 });
 export type CollectionTrigger = z.infer<typeof CollectionTriggerSchema>;
 


### PR DESCRIPTION
## 배경

YouTube가 자막 엔드포인트(`api/timedtext`)에 PO token 보호를 확대하면서, 쿠키·PO token 없이는 자막 다운로드가 HTTP 429로 거부된다. 기존 `fetchTranscript`는 영상마다 개별 호출되어 차단 상태에서 N개 영상 = N번의 무의미한 429 요청 → 차단 심화 + 수집 시간 낭비.

## 변경 내용

### 1. Run 단위 회로 차단기 (자동 동작)
- `fetchTranscript` 반환을 판별 유니온(`TranscriptResult`)으로 변경 — 429/403만 `blocked: true`로 분류
- 한 수집 run 내에서 차단을 2회(`TRANSCRIPT_BLOCK_THRESHOLD`) 누적하면 회로가 열려 그 run의 나머지 영상은 자막 호출을 스킵
- 회로가 열려도 기존 Whisper(조회수 상위 20건)·description 폴백은 그대로 작동
- run 스코프 지역 상태(동시 run 오염 방지), 순수 함수 `evaluateTranscriptCircuit`로 분리해 테스트 용이
- 다음 run에서 자동 재시도 (차단은 일시적일 수 있으므로)
- collector-worker 종료 로그에 `[transcript-circuit-open skipped=N]` 배지로 운영 가시성 확보

### 2. 사용자 제어 토글 (`transcriptAutoSkipOnBlock`)
- 회로 차단기 동작을 사용자가 켜고/끌 수 있는 옵션을 전 경로에 연결 (collector 스키마 → 큐 → executor → DB → tRPC → UI)
- **기본 ON**, 소비·복원·매핑 모든 지점에서 `!== false` 관용구로 기존 구독도 활성 유지
- "유튜브 자막 수집"이 켜질 때만 하위 토글로 노출 (구독 폼 + 분석 실행 폼)
- OFF는 차단을 무시하고 모든 영상에서 재시도하는 escape hatch (비권장)

## 주의 사항

- **구독 수집 경로(apps/collector)만 end-to-end 동작.** 키워드 단발 분석(core collector-worker)은 자막 옵션이 수집까지 도달하지 않는 기존 한계가 있으며(기존 `collectTranscript`도 동일), 이번 PR에서는 손대지 않음.
- collector tRPC `optionsSchema`의 Zod strip이 실제 데이터 손실 지점이었고 해소함 (web 구독 폼 저장 경로).
- `transcriptAutoSkipOnBlock`는 jsonb 컬럼 내 필드라 DB 마이그레이션 불필요 (기존 행은 undefined = 활성).

## 테스트

- `youtube-transcript.test.ts` (신규) — 반환 신호 분류 5개 (429/403 → blocked, no_tracks → not blocked, 정상 자막)
- `youtube-transcript-circuit.test.ts` (신규) — 회로 상태 전이 6개 + 게이트 동작 2개 (OFF 시 회로 안 열림)
- collectors 전체 테스트 통과, `tsc` 타입체크 통과 (collectors + core + collector + web)

## 배포 후 확인 필요

dev 환경에서는 차단이 재현되지 않음(테스트 영상 전부 성공). 실제 차단이 429로 표면화되는지 첫 운영 run의 로그(`[transcript] reason=`)·stats로 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)